### PR TITLE
feat: add SkillKit integration for 32+ AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,17 @@ Install skills for any coding agent
 npx skills add superdesigndev/superdesign-skill
 ```
 
+Or use [SkillKit](https://github.com/rohitg00/skillkit) for 32+ AI agents:
+```
+npx skillkit install superdesign
+```
+
+Translate to your preferred agent:
+```
+npx skillkit translate superdesign --agent cursor
+npx skillkit translate superdesign --agent codex
+```
+
 Prompt in any agent
 ```
 /superdesign help me design X

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: superdesign
+description: Design agent for UI/UX design - find inspirations, generate design drafts, iterate on infinite canvas
+author: superdesigndev
+version: 1.0.0
+tags:
+  - design
+  - ui
+  - ux
+  - frontend
+  - figma
+  - prototyping
+agents:
+  - claude-code
+  - cursor
+  - codex
+  - windsurf
+  - cline
+  - continue
+  - github-copilot
+  - universal
+---
+
+# SuperDesign
+
+Design agent specialized in frontend UI/UX design. Use this skill before implementing any UI that requires design thinking.
+
+## Core Capabilities
+
+1. **Help me design X** - Design features, pages, or flows
+2. **Set design system** - Create or extract design systems
+3. **Help me improve design of X** - Iterate and refine existing designs
+
+## Prerequisites
+
+```bash
+npm install -g @superdesign/cli@latest
+superdesign login
+```
+
+## Quick Start
+
+```bash
+# Search for design inspiration
+superdesign search-prompts --tags "style" --json
+
+# Create a project
+superdesign create-project --title "My App" --json
+
+# Create design variations
+superdesign iterate-design-draft --draft-id <id> -p "dark theme" -p "minimal" --mode branch --json
+```
+
+## Workflow for Existing Apps
+
+1. Investigate existing UI and workflow
+2. Setup design system at `.superdesign/design-system.md`
+3. Gather requirements using `askQuestion`
+4. Create pixel-perfect replica in `.superdesign/replica_html_template/<name>.html`
+5. Create project with replica + design system
+6. Iterate designs with branching
+
+## Key Commands
+
+```bash
+# Inspiration & Style
+superdesign search-prompts --keyword "<keyword>" --json
+superdesign get-prompts --slugs "<slug1,slug2>" --json
+superdesign extract-brand-guide --url https://example.com --json
+
+# Canvas Design
+superdesign create-project --title "X" --set-project-prompt-file .superdesign/design-system.md --json
+superdesign iterate-design-draft --draft-id <id> -p "..." --mode branch --json
+superdesign execute-flow-pages --draft-id <id> --pages '[...]' --json
+superdesign get-design --draft-id <id> --json
+```
+
+## Design System
+
+Design system lives at: `.superdesign/design-system.md`
+
+Options:
+- **Extract from codebase**: Analyze existing tokens, colors, typography
+- **Create new**: Use `search-prompts --tags "style"` for inspiration
+
+## Resources
+
+- [Full Documentation](https://github.com/superdesigndev/superdesign-skill)
+- [SuperDesign CLI](https://www.npmjs.com/package/@superdesign/cli)


### PR DESCRIPTION
## Summary

This PR adds SkillKit integration, enabling the superdesign skill to be installed across 32+ AI coding agents with a single command.

## Changes

- **SKILL.md**: Added with proper frontmatter for SkillKit marketplace compatibility
  - Metadata: name, description, author, version, tags, supported agents
  - Documentation: Quick start, key commands, workflow overview
  
- **README.md**: Added SkillKit installation as an alternative option
  - `npx skillkit install superdesign`
  - `npx skillkit translate superdesign --agent <agent-name>`

## Benefits

- **Wider reach**: Available to 32+ AI agents (Cursor, Codex, Gemini CLI, Windsurf, Cline, etc.)
- **Marketplace listing**: Discoverable at https://agenstskills.com
- **Cross-agent translation**: Auto-translates skill format for each agent's native format
- **Team collaboration**: Teams can share and sync skills across preferred agents

## Supported Agents

Claude Code, Cursor, Codex, Windsurf, Cline, Continue, GitHub Copilot, Gemini CLI, OpenCode, Goose, and 22+ more.

## Resources

- SkillKit: https://github.com/rohitg00/skillkit
- Marketplace: https://agenstskills.com
- npm: https://www.npmjs.com/package/skillkit