### PR TITLE
docs: enhance context completeness with pages dependency trees

### DIFF
--- a/skills/superdesign/INIT.md
+++ b/skills/superdesign/INIT.md
@@ -68,12 +68,45 @@ Extract the design system / theme tokens. **Include FULL file contents**, not su
 - Full CSS variable definitions
 - Any design token files
 
+### 6. Write `pages.md`
+For each key page/route in the app (home, dashboard, main features — up to 10 pages), build a **complete component dependency tree** by tracing imports recursively.
+
+For each page:
+1. Start from the page component file
+2. Trace ALL local imports (relative `./Foo`, `../Bar`, alias `@/components/Baz` — skip node_modules)
+3. For each import, trace ITS imports recursively
+4. Present as an indented tree showing every file the page depends on
+
+Format:
+```
+## / (Home Page)
+Entry: src/app/(home)/home-page.tsx
+Dependencies:
+- src/components/home-ui/elegant-header.tsx
+  - src/components/team/create-team-modal.tsx
+- src/components/home-ui/elegant-hero-section.tsx
+  - src/components/home-ui/home-hero-input.tsx
+  - src/components/home-ui/persona-selector.tsx
+  - src/components/home-ui/dev-workflow-view.tsx
+  - src/components/home-ui/import-site-modal.tsx
+- src/components/home-ui/elegant-project-grid.tsx
+  - src/components/home-ui/elegant-project-card.tsx
+- src/app/(home)/components/template-browse-section.tsx
+  - src/app/(home)/components/template-card.tsx
+- src/components/layout/Footer.tsx
+```
+
+This tree is the **SINGLE SOURCE OF TRUTH** for which files to pass as `--context-file` when designing a page. If a file appears in the tree, it MUST be included.
+
+Prioritize the most important/complex pages (home, dashboard, settings, etc.). Skip trivial pages (404, offline, status).
+
 ## Format Guidelines
 - Use markdown with clear headings
 - Include file paths as code spans
 - **For `components.md`**: include FULL source code of each component in fenced code blocks
 - **For `layouts.md`**: include FULL file contents in fenced code blocks
 - **For `theme.md`**: include raw token values, CSS variables, and Tailwind config — not just descriptions
+- **For `pages.md`**: include complete dependency trees with indentation showing nesting depth
 - Keep descriptions concise — the goal is machine-readable context, not documentation
 
 ## Key Principle: INCLUDE ACTUAL CODE

--- a/skills/superdesign/SKILL.md
+++ b/skills/superdesign/SKILL.md
@@ -21,6 +21,7 @@ SuperDesign helps you (1) find design inspirations/styles and (2) generate/itera
 # Init: Repo Analysis
 
 When `.superdesign/init/` directory doesn't exist or is empty, you MUST automatically:
+
 1. Create the `.superdesign/init/` directory
 2. Fetch the init prompt from the URL below
 3. Follow the prompt instructions to analyze the repo and write context files
@@ -31,16 +32,17 @@ https://raw.githubusercontent.com/superdesigndev/superdesign-skill/main/skills/s
 
 Do NOT ask the user to do this manually — just do it.
 
-# MANDATORY: Read Init Files Every Time
+# Mandatory Init Files
 
-**CRITICAL**: When `.superdesign/init/` exists, you MUST read ALL files in this directory at the START of every design task:
-- `components.md` — shared UI primitives inventory
-- `layouts.md` — full source code of layout components
-- `routes.md` — route/page mapping
+If `.superdesign/init/` exists, you MUST read ALL files in this directory FIRST before any design task:
+
+- `components.md` — shared UI primitives with full source code
+- `layouts.md` — shared layout components (nav, sidebar, header, footer)
+- `routes.md` — page/route mapping
 - `theme.md` — design tokens, CSS variables, Tailwind config
+- `pages.md` — page component dependency trees (which files each page needs)
 
-These files contain pre-analyzed codebase context that is ESSENTIAL for accurate design reproduction. Reading them is NOT optional — it's mandatory for every design task.
-
+**When designing for an existing page**: First check `pages.md` for the page's complete dependency tree. Every file in that tree MUST be passed as `--context-file`. Then also add globals.css, tailwind.config, and design-system.md.
 
 # Superdesign CLI (MUST run before any command)
 
@@ -49,14 +51,17 @@ These files contain pre-analyzed codebase context that is ESSENTIAL for accurate
 Follow these steps in order — do NOT skip any step:
 
 1. Check if CLI is already installed:
+
    ```
    superdesign --version
    ```
+
    - If the command succeeds (prints a version), **skip installation** and go to step 2.
    - If the command fails (not found), install the CLI:
      ```
      npm install -g @superdesign/cli@latest
      ```
+
 2. Check login status by running any command (e.g. `superdesign --help`). If you see an auth/login error, run:
    ```
    superdesign login
@@ -67,7 +72,9 @@ Follow these steps in order — do NOT skip any step:
 > **Never assume the user is already logged in.** Always verify login first.
 
 # How it works
+
 MUST MANDATORY Fetch fresh guidelines below:
+
 ```
 https://raw.githubusercontent.com/superdesigndev/superdesign-skill/main/skills/superdesign/SUPERDESIGN.md
 ```


### PR DESCRIPTION
## Summary
- Add `pages.md` init step with recursive component dependency tree format
- Enhance context collection guidelines — clear rules on what to include vs strip
- Update SKILL.md to reference pages.md as mandatory init file

## Test plan
- [ ] Review documentation for clarity and completeness
- [ ] Verify examples are accurate and useful
- [ ] Check guidelines align with SuperDesign context requirements