### PR TITLE
Reframe README: 'design skill for Claude Code, stop AI-slop UI' + MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Superdesign (superdesign.dev)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,43 @@
-SuperDesign helps you (1) find design inspirations/styles and (2) generate/iterate design drafts on an infinite canvas.
+# Superdesign: the design skill for Claude Code, Cursor and any coding agent
+
+**Stop shipping AI-slop UI.** Coding agents write great code and mediocre interfaces: generic layouts, default shadcn everything, no taste. Superdesign is the skill that gives your agent design judgment, so the UI it ships actually looks considered.
+
+Install it once and your agent (Claude Code, Cursor, Codex, and 70+ others) can find real design direction, set up a design system, and generate + iterate high-quality UI drafts on an infinite canvas, all without leaving your terminal.
+
+> Powered by [superdesign.dev](https://superdesign.dev), the AI product design agent.
+
+---
+
+## Install
+
+```
+npx skills add superdesigndev/superdesign-skill
+```
+
+This works for any of the [70+ supported coding agents](https://github.com/vercel-labs/skills#supported-agents). Then install the CLI it drives:
+
+```
+npm install -g @superdesign/cli@latest
+superdesign login
+```
+
+## Use it
+
+Just talk to your agent:
+
+```
+/superdesign help me redesign this settings page so it doesn't look like default AI slop
+```
+
+```
+/superdesign set up a design system from my current codebase
+```
+
+```
+/superdesign improve the design of my dashboard
+```
+
+The skill handles the rest: it reads your code for context, gathers real style references, and produces design drafts you can branch and refine.
 
 ---
 
@@ -6,26 +45,7 @@ SuperDesign helps you (1) find design inspirations/styles and (2) generate/itera
 
 1. **Help me design X** (feature/page/flow)
 2. **Set design system**
-3. **Help me improve design of X**
-
-# Quickstart
-
-Install CLI
-```
-npm install -g @superdesign/cli@latest
-```
-
-Install skills for any coding agent
-```
-npx skills add superdesigndev/superdesign-skill
-```
-
-Prompt in any agent
-```
-/superdesign help me design X
-```
-
---
+3. **Help me improve design of X** (make it not look AI-generated)
 
 ## Tooling overview
 
@@ -253,3 +273,14 @@ superdesign get-design --draft-id <id> --json
 # Create new design from scracth without any reference - ONLY use this for creating brand new design, default NEVER use this
 superdesign create-design-draft --project-id <id> --title "X" -p "..." --json
 ```
+
+---
+
+## Links
+
+- Web app: [superdesign.dev](https://superdesign.dev)
+- Skill install for 70+ agents: [vercel-labs/skills](https://github.com/vercel-labs/skills)
+
+## License
+
+MIT. See [LICENSE](./LICENSE).


### PR DESCRIPTION
## Why
The repo already ranks/exists (315★) but presents itself as an "infinite canvas reference layer," not as **the installable design skill for coding agents**. That framing costs us on two fronts:
- **GitHub search + LLM answer-sets** (e.g. "best design skill for Claude Code") read the first lines of the README and repo card.
- **awesome-list maintainers** glance at the repo before accepting a PR to add us. A canvas-first pitch reads as niche and risks getting mis-filed.

This is the on-repo half of the GEO off-site push (getting Superdesign into awesome-claude-skills lists + "best claude skills" listicles that LLMs cite).

## What changed
- **README top reframed** to lead with *"the design skill for Claude Code, Cursor and any coding agent"* + *"stop shipping AI-slop UI"* value prop.
- Added an **Install** block and concrete **Use it** prompts up top.
- All canvas/SOP/command-reference content is **unchanged**, just moved below the fold.
- Added **MIT LICENSE** (was unlicensed) + a links/license footer.

## Also done outside this PR (repo settings)
- Set repo **description** (keyword-aligned, no em-dash per brand voice), **homepage** → superdesign.dev, and **12 topics** (claude-code, claude-skill, agent-skills, ui-design, design-agent, cursor, …).

## Not touched
- No changes to `SKILL.md`, `INIT.md`, `SUPERDESIGN.md`, or `INSTALL.md` — behavior of the skill itself is identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMix3Xorg1rSPVvtJqWej8