### PR TITLE
Fix invalid JSON placeholders in skill command examples

### DIFF
--- a/skills/superdesign/SKILL.md
+++ b/skills/superdesign/SKILL.md
@@ -66,11 +66,13 @@ Always use the full on-demand runner prefix:
 npx --yes @superdesign/cli@latest create-project --title "X"
 npx --yes @superdesign/cli@latest create-design-draft --project-id <id> --title "Current UI" -p "Faithfully reproduce..." --context-file src/Component.tsx
 npx --yes @superdesign/cli@latest iterate-design-draft --draft-id <id> -p "dark theme" -p "minimal" --mode branch --context-file src/Component.tsx
-npx --yes @superdesign/cli@latest execute-flow-pages --draft-id <id> --pages '[...]' --context-file src/Component.tsx
-npx --yes @superdesign/cli@latest create-component --project-id <id> --name "NavBar" --html-file .superdesign/tmp/navbar.html --props '[...]'
+npx --yes @superdesign/cli@latest execute-flow-pages --draft-id <id> --pages '[{"title":"Details","prompt":"Create the details page"}]' --context-file src/Component.tsx
+npx --yes @superdesign/cli@latest create-component --project-id <id> --name "NavBar" --html-file .superdesign/tmp/navbar.html --props '[{"name":"activeItem","type":"string","defaultValue":"home"}]'
 npx --yes @superdesign/cli@latest update-component --component-id <id> --html-file .superdesign/tmp/navbar.html
 npx --yes @superdesign/cli@latest list-components --project-id <id>
 ```
+
+JSON option examples are literal valid JSON; preserve the outer shell quotes and replace values, not brackets/keys.
 
 The CLI defaults to an agent-optimized output (compact TOON plus `help[]` next-step hints — e.g. `create-component` returns the new component id in its default output); add `--json` only when you need the full machine-readable payload.
 

--- a/skills/superdesign/SKILL.md
+++ b/skills/superdesign/SKILL.md
@@ -66,11 +66,13 @@ Always use the full on-demand runner prefix:
 npx --yes @superdesign/cli@latest create-project --title "X"
 npx --yes @superdesign/cli@latest create-design-draft --project-id <id> --title "Current UI" -p "Faithfully reproduce..." --context-file src/Component.tsx
 npx --yes @superdesign/cli@latest iterate-design-draft --draft-id <id> -p "dark theme" -p "minimal" --mode branch --context-file src/Component.tsx
-npx --yes @superdesign/cli@latest execute-flow-pages --draft-id <id> --pages '[{"title":"Details","prompt":"Create the details page"}]' --context-file src/Component.tsx
+npx --yes @superdesign/cli@latest execute-flow-pages --draft-id <id> --pages '[{"title":"Product Details","prompt":"Product detail page with image gallery, specs and add-to-cart"},{"title":"Checkout","prompt":"Checkout page with cart summary and payment form"}]' --context-file src/Component.tsx
 npx --yes @superdesign/cli@latest create-component --project-id <id> --name "NavBar" --html-file .superdesign/tmp/navbar.html --props '[{"name":"activeItem","type":"string","defaultValue":"home"}]'
 npx --yes @superdesign/cli@latest update-component --component-id <id> --html-file .superdesign/tmp/navbar.html
 npx --yes @superdesign/cli@latest list-components --project-id <id>
 ```
+
+Each item in the `execute-flow-pages` `--pages` array generates one new page styled after the source draft (1-10 pages per call).
 
 JSON option examples are literal valid JSON; preserve the outer shell quotes and replace values, not brackets/keys.
 

--- a/skills/superdesign/references/SUPERDESIGN.md
+++ b/skills/superdesign/references/SUPERDESIGN.md
@@ -215,7 +215,7 @@ Step 3 — Design in Superdesign
 
 Extension after approval:
 
-- If user wants to design more relevant pages or whole user journey based on a design, use execute-flow-pages: `npx --yes @superdesign/cli@latest execute-flow-pages --draft-id <draftId> --pages '[...]' --context-file src/components/Foo.tsx`
+- If user wants to design more relevant pages or whole user journey based on a design, use execute-flow-pages: `npx --yes @superdesign/cli@latest execute-flow-pages --draft-id <draftId> --pages '[{"title":"Details","prompt":"Create the details page"}]' --context-file src/components/Foo.tsx`
 - IMPORTANT: Use execute-flow-pages instead of create-design-draft for extend more pages based on existing design, create-design-draft is ONLY used for creating brand new design
 
 ## SOP: BRAND NEW PROJECT

--- a/skills/superdesign/references/SUPERDESIGN.md
+++ b/skills/superdesign/references/SUPERDESIGN.md
@@ -215,7 +215,7 @@ Step 3 — Design in Superdesign
 
 Extension after approval:
 
-- If user wants to design more relevant pages or whole user journey based on a design, use execute-flow-pages: `npx --yes @superdesign/cli@latest execute-flow-pages --draft-id <draftId> --pages '[{"title":"Details","prompt":"Create the details page"}]' --context-file src/components/Foo.tsx`
+- If user wants to design more relevant pages or whole user journey based on a design, use execute-flow-pages: `npx --yes @superdesign/cli@latest execute-flow-pages --draft-id <draftId> --pages '[{"title":"Product Details","prompt":"Product detail page with image gallery, specs and add-to-cart"},{"title":"Checkout","prompt":"Checkout page with cart summary and payment form"}]' --context-file src/components/Foo.tsx`
 - IMPORTANT: Use execute-flow-pages instead of create-design-draft for extend more pages based on existing design, create-design-draft is ONLY used for creating brand new design
 
 ## SOP: BRAND NEW PROJECT


### PR DESCRIPTION
## What

The shallow `SKILL.md` command list taught `--pages '[...]'` and `--props '[...]'`, plus one matching `--pages '[...]'` example in `references/SUPERDESIGN.md`. These look executable but `[...]` is not valid JSON, so agents that copy the nearest example fail with a guaranteed `validation_error`. Telemetry attributes a measurable share of the create-component (36%) / execute-flow-pages (51%) failure rates to this (see investigation report, section 5).

## Changes

- `skills/superdesign/SKILL.md` (shallow command list): replace both `'[...]'` placeholders with valid minimal JSON:
  - `execute-flow-pages`: `--pages '[{"title":"Details","prompt":"Create the details page"}]'`
  - `create-component`: `--props '[{"name":"activeItem","type":"string","defaultValue":"home"}]'`
- Add a note near the command list: "JSON option examples are literal valid JSON; preserve the outer shell quotes and replace values, not brackets/keys."
- `references/SUPERDESIGN.md:218`: replace the remaining `--pages '[...]'` placeholder with the same valid JSON.

The `"..."` examples elsewhere (SUPERDESIGN.md:321, README.md) are valid JSON strings that parse fine, and the deep command contract (SUPERDESIGN.md:542) is accurate — both left untouched.

## Verification

Every touched flag and JSON snippet verified against `@superdesign/cli@latest`:
- `execute-flow-pages --help` / `create-component --help` confirm `--pages`, `--props`, `--project-id`, `--name`, `--html-file`, `--draft-id`, `--context-file`.
- Each JSON snippet parses via `node -e 'JSON.parse(...)'`.

No version bump; `.codex-plugin` packaging untouched.