### PR TITLE
feat(skill): add no-context branch, canvas URL surfacing, and Chat-mode preflight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,10 @@ A published agent **skill** (`skills/superdesign/`) that drives the SuperDesign 
 - `skills/superdesign/references/INIT.md` - repo-analysis (init) instructions
 - `skills/superdesign/{SUPERDESIGN,INIT}.md` - deprecated compatibility forwarders (do not add content)
 
+## Skill flow invariant: two entry paths
+
+`SKILL.md` branches on Step 1 into a **real-codebase path** (repo init is mandatory) and a **no-codebase path** (empty/scratch/sandbox workspace with no frontend code - skip init, gather design context conversationally, design via `SUPERDESIGN.md` "SOP: BRAND NEW PROJECT"). Any init/hard-gate rule you edit must stay scoped to the real-codebase path so it does not block the no-codebase path (see the HARD GATE and MANDATORY INIT rules in `SUPERDESIGN.md`). A separate Step 0 preflight halts when shell execution is unavailable (e.g. ChatGPT Chat mode) - distinct from the auth/login path, where the CLI actually ran.
+
 ## Ground truth for CLI behavior
 
 The skill invokes `npx --yes @superdesign/cli@latest`. When editing any command example or the `COMMAND CONTRACT`, verify against the **published** CLI - do not trust memory. `@beta` is what `@latest` becomes, so use it to check upcoming surface:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,8 +7,10 @@ preview link. Do NOT stop at login.
 The flow is simple and sequential: **install → log in → init → ask what to design → design.** Do NOT
 propose design ideas, and do NOT run things in parallel — just init, then ask the user what they want.
 
-> ⛔ **Hard gate:** do NOT create a project, create a draft, or run ANY `superdesign` design command until
-> `init` has finished (`.superdesign/init/` written with all files).
+> ⛔ **Hard gate (real-codebase path):** do NOT create a project, create a draft, or run ANY `superdesign`
+> design command until `init` has finished (`.superdesign/init/` written with all files). This flow assumes a
+> real codebase to init; for an empty/scratch/sandbox workspace there is nothing to init — see the no-codebase
+> branch in `skills/superdesign/SKILL.md` (Step 1).
 
 ## Step 1 — Install the Superdesign skill into yourself
 

--- a/skills/superdesign/SKILL.md
+++ b/skills/superdesign/SKILL.md
@@ -30,7 +30,7 @@ Two entry paths. Choose one with this cheap, deterministic check BEFORE any init
 
 - No `.superdesign/init/` files already exist, AND
 - No dependency manifest with frontend deps (no `package.json`, or a `package.json` whose deps include no frontend framework/UI library — react, vue, svelte, angular, next, nuxt, astro, etc.), AND
-- No frontend source found (a quick scan for `.tsx`/`.jsx`/`.vue`/`.svelte` files, or a `src/`/`app/`/`components/` dir with UI files, turns up nothing).
+- No frontend source found (a quick scan for `.tsx`/`.jsx`/`.vue`/`.svelte` files, any `.html`/`.css` files such as a root `index.html` + `style.css`, or a `src/`/`app/`/`components/` dir with UI files, turns up nothing).
 
 → SKIP repo init entirely. Do NOT "analyze" an empty sandbox, and do NOT ask the user to point you at a repo they don't have. Instead, gather design context conversationally FIRST: ask what they want to build, the target audience/platform, style/brand preferences, and any reference designs or inspirations. Then design from that conversation via the **BRAND NEW PROJECT** path in `references/SUPERDESIGN.md`.
 

--- a/skills/superdesign/SKILL.md
+++ b/skills/superdesign/SKILL.md
@@ -14,9 +14,31 @@ Superdesign helps you (1) find design inspirations/styles and (2) generate/itera
 3. **Set design system**
 4. **Help me improve design of X**
 
-# Init: Repo Analysis
+# Step 0 — Environment preflight (BEFORE any CLI step)
 
-When `.superdesign/init/` directory doesn't exist or is empty, you MUST automatically:
+Superdesign runs entirely through its CLI, so you must be able to execute shell commands. Confirm that capability FIRST, before any CLI verification:
+
+- If you have NO way to run shell commands in this environment (no terminal/execution tool at all), OR your very first `npx --yes @superdesign/cli@latest --version` attempt fails because command execution itself is unavailable (the harness reports it cannot run commands / there is no shell) — as opposed to the command running and returning an error — then STOP. Do NOT keep retrying or improvise workarounds.
+- Tell the user plainly: Superdesign needs an environment with terminal access. In ChatGPT/Codex that means switching from **Chat mode** to **Work mode** (a workspace/sandbox with a terminal). Then offer to continue the design conversation right now — gathering requirements (see the design-context questions in Step 1) — so the work is ready to run the moment they switch.
+- **Do NOT confuse this with an auth/login error.** A login/auth error means the CLI actually ran (execution works) — handle that via the login step below, not here. This branch is ONLY for when command execution itself is unavailable. ChatGPT Chat mode is the concrete example, but treat it generally: any harness with no shell/execution capability takes this branch.
+
+# Step 1 — Is there a codebase to analyze?
+
+Two entry paths. Choose one with this cheap, deterministic check BEFORE any init or design work.
+
+**No meaningful codebase** (empty workspace, scratch/sandbox dir, no frontend code) — treat the workspace as "no codebase" when ALL of these hold:
+
+- No `.superdesign/init/` files already exist, AND
+- No dependency manifest with frontend deps (no `package.json`, or a `package.json` whose deps include no frontend framework/UI library — react, vue, svelte, angular, next, nuxt, astro, etc.), AND
+- No frontend source found (a quick scan for `.tsx`/`.jsx`/`.vue`/`.svelte` files, or a `src/`/`app/`/`components/` dir with UI files, turns up nothing).
+
+→ SKIP repo init entirely. Do NOT "analyze" an empty sandbox, and do NOT ask the user to point you at a repo they don't have. Instead, gather design context conversationally FIRST: ask what they want to build, the target audience/platform, style/brand preferences, and any reference designs or inspirations. Then design from that conversation via the **BRAND NEW PROJECT** path in `references/SUPERDESIGN.md`.
+
+**Real codebase present** (any frontend code, or an existing `.superdesign/init/`) — the repo-init path below is MANDATORY; run the full analysis before designing.
+
+# Init: Repo Analysis (real-codebase path)
+
+When a real codebase is present (per Step 1) and the `.superdesign/init/` directory doesn't exist or is empty, you MUST automatically:
 
 1. Create the `.superdesign/init/` directory
 2. Read `references/INIT.md` relative to this selected `SKILL.md`
@@ -82,6 +104,12 @@ Create the workspace-local `.superdesign/tmp/` directory with the session's file
 Ensure `.superdesign/tmp/` is ignored by the project's `.gitignore`; append the entry if it is missing so temporary HTML is never committed.
 
 `--context-file` supports `path:startLine:endLine`; see `references/SUPERDESIGN.md` for the complete workflow and current command contract.
+
+# Surface the canvas URL
+
+Every project/draft command's default output includes a `canvas:` link (the project canvas, `https://superdesign.dev/teams/<teamId>/projects/<projectId>`) and, for drafts, a `preview:` link (`https://superdesign.dev/preview/draft/<draftId>`). Read these from the command output — do NOT hand-construct them (the ids are server-generated).
+
+After creating a project or design draft, and at natural review moments (after `iterate-design-draft` or `execute-flow-pages`), give the user the `canvas` URL as a clickable link and invite them to open it to watch designs stream in and leave feedback. Adding `?live=1` to the canvas URL opens the live view where drafts appear as they generate.
 
 # How it works
 

--- a/skills/superdesign/references/SUPERDESIGN.md
+++ b/skills/superdesign/references/SUPERDESIGN.md
@@ -2,7 +2,7 @@ You are "Superdesign Agent". Your job is to use Superdesign to generate and iter
 
 IMPORTANT: MUST produce design on superdesign, only implement actual code AFTER user approve OR the user explicitly says 'skip design and implement'
 
-⛔ HARD GATE — INIT BEFORE ANY DESIGN: NEVER run `npx --yes @superdesign/cli@latest create-project`, `npx --yes @superdesign/cli@latest create-design-draft`, `npx --yes @superdesign/cli@latest iterate-design-draft`, or `npx --yes @superdesign/cli@latest execute-flow-pages` until `.superdesign/init/` exists with all files (init complete). If init is missing or still running, WAIT for it to finish first. Creating a project or draft before init is done is a hard error.
+⛔ HARD GATE — INIT BEFORE ANY DESIGN (real-codebase path only): When a real codebase is present, NEVER run `npx --yes @superdesign/cli@latest create-project`, `npx --yes @superdesign/cli@latest create-design-draft`, `npx --yes @superdesign/cli@latest iterate-design-draft`, or `npx --yes @superdesign/cli@latest execute-flow-pages` until `.superdesign/init/` exists with all files (init complete). If init is missing or still running, WAIT for it to finish first. Creating a project or draft before init is done is a hard error. This gate does NOT apply to the no-codebase path (empty/scratch/sandbox workspace with no frontend code — see SKILL.md Step 1): there is nothing to init, so gather design context conversationally and design directly via **SOP: BRAND NEW PROJECT** below.
 
 ## SOP: EXISTING UI
 
@@ -199,7 +199,7 @@ Step 3 — Design in Superdesign
   ⚠️ Pass the SAME context files as Step 3a to maintain consistency.
   When this iteration is driven by a user request, pass that user's verbatim message via `--user-request` (see USER REQUEST PASSING below). The device/viewport is inherited from the source draft automatically — do NOT re-specify `--device` unless you are deliberately changing it.
 
-- Present URL & title to user and ask for feedback
+- Present the `canvas` URL (from the command output) as a clickable link and the title to the user; invite them to open the canvas to watch designs stream in and leave feedback, then ask for their feedback. (`?live=1` on the canvas URL opens the live streaming view.)
 - Before further iteration, MUST read the design first: `npx --yes @superdesign/cli@latest get-design --draft-id <id> --json`
 
 ⛔ COMMON MISTAKES — DO NOT DO THESE:
@@ -237,7 +237,7 @@ Step 3 — Design in Superdesign:
 
 - Create project: `npx --yes @superdesign/cli@latest create-project --title "<X>"`
 - Create initial draft (only for brand new, ⚠️ single -p only): `npx --yes @superdesign/cli@latest create-design-draft --project-id <id> --title "<X>" -p "<all design directions in one prompt>" --user-request "<the user's verbatim request>"`
-- Present URL(s), gather feedback, iterate.
+- Present the `canvas` URL(s) from the command output as clickable links; invite the user to open the canvas to watch designs stream in and leave feedback, then gather feedback and iterate.
 - Iterate in BRANCH mode;
 
 ---
@@ -348,7 +348,7 @@ Every draft keeps a version history. The CLI's default output already self-discl
 
 - Design system file path is fixed: .superdesign/design-system.md
 - design-system.md = ALL design specs
-- **MANDATORY INIT**: If `.superdesign/init/` is missing or incomplete, you MUST run the full init analysis FIRST (follow the INIT instructions from the skill). If it exists, you MUST read ALL files (components.md, layouts.md, routes.md, theme.md, pages.md, extractable-components.md) at the START of every design task. This is NOT optional.
+- **MANDATORY INIT (real-codebase path)**: When a real codebase is present, if `.superdesign/init/` is missing or incomplete you MUST run the full init analysis FIRST (follow the INIT instructions from the skill); if it exists, you MUST read ALL files (components.md, layouts.md, routes.md, theme.md, pages.md, extractable-components.md) at the START of every design task. This is NOT optional. On the no-codebase path (empty/scratch/sandbox workspace, no frontend code — see SKILL.md Step 1), there is nothing to init: skip it and gather design context conversationally instead.
 - **MANDATORY CONTEXT FILES on EVERY design command** (create-design-draft, iterate-design-draft, execute-flow-pages):
   - `--context-file .superdesign/design-system.md` — so the design agent knows the allowed fonts, colors, spacing
   - `--context-file <path-to-globals.css>` — so the design agent has the actual CSS tokens and variables


### PR DESCRIPTION
## Intent

Three UX fixes to the superdesign agent skill docs (prose-only skill repo, no build/test suite), driven by real Codex Plugin user feedback. All product/agent-facing text is English-only, kept in SKILL.md's existing terse imperative style. (1) No-context branch: SKILL.md new Step 1 branches on a deterministic 'no meaningful codebase' heuristic (no .superdesign/init/, no frontend deps in package.json, no frontend source) so empty/scratch/sandbox workspaces SKIP repo init and gather design context conversationally, then design via the existing BRAND NEW PROJECT SOP. Deliberately scoped (not weakened) the init HARD GATE and MANDATORY INIT rules in SUPERDESIGN.md to the real-codebase path so the existing-project flow stays fully mandatory. (2) Canvas URL surfacing: new section instructs the agent to read the canvas:/preview: links from the CLI default output (never hand-construct them - ids are server-generated) and share them after create/iterate/flow-page steps, inviting users to watch designs stream in via ?live=1 and leave feedback; URL shapes verified against published CLI source axi-output.ts/axi-renderers.ts. (3) Chat-mode preflight: new Step 0 halts before any CLI step when shell execution itself is unavailable (e.g. ChatGPT Chat mode), tells the user to switch to Work mode, and offers to continue the conversation - deliberately distinguished from the auth/login path where the CLI actually ran, and generalized to any no-execution harness. Recorded the two-path invariant in AGENTS.md (plain-dash style matched there; em dashes kept in SKILL/SUPERDESIGN to match those files' idiom). No dist/build artifacts to regenerate and no version bump, per the repo's prose-skill convention. PR #16 already open.

## What Changed

- Added a new Step 1 branch in `SKILL.md` that runs a deterministic "no meaningful codebase" check (no `.superdesign/init/`, no frontend deps in `package.json`, no frontend source including vanilla `.html`/`.css`); empty/scratch/sandbox workspaces skip repo init and gather design context conversationally before designing via the BRAND NEW PROJECT SOP. Scoped (not weakened) the init HARD GATE, MANDATORY INIT, and `INSTALL.md` hard gate to the real-codebase path so the existing-project flow stays mandatory.
- Added a "Surface the canvas URL" section instructing the agent to read the server-generated `canvas:`/`preview:` links from CLI default output (never hand-construct them) and share them after create/iterate/flow-page steps, inviting users to watch designs stream in via `?live=1`; updated `SUPERDESIGN.md` present-URL steps accordingly.
- Added a Step 0 environment preflight that halts before any CLI step when shell execution itself is unavailable (e.g. ChatGPT Chat mode), tells the user to switch to Work mode, and offers to keep gathering requirements — explicitly distinguished from the auth/login path where the CLI actually ran. Recorded the two-path invariant in `AGENTS.md`.

## Risk Assessment

✅ Low: Prose-only documentation change to a build/test-free skill repo; the sole new commit cleanly applies the previously-agreed heuristic fix, is properly scoped, and introduces no new problems.

## Testing

Baseline is a prose-only skill repo with no build/test suite, so I verified the one testable behavioral claim — canvas/preview URL shapes and default-output surfacing — directly against the published CLI source (v0.5.1), where every documented URL and label matched exactly, and confirmed the new Step 0 preflight, Step 1 no-codebase branch, and scoped init gates render coherently with resolvable cross-references; captured a full-page screenshot of the rendered SKILL.md as visual evidence. All claims hold; no issues found.

- Evidence: Rendered SKILL.md (all three new sections: Step 0 preflight, Step 1 codebase branch, Surface the canvas URL) (local file: <code>/var/folders/5h/2z3x38y52m5c9scwr9vdx8qc0000gn/T/no-mistakes-evidence/01KXPS1TJVPTF33HHYB70FNSN5/skill-rendered.png</code>)
<details>
<summary>Evidence: Published CLI source confirming documented URL shapes</summary>

```text
package/dist/index.js:
previewUrlFor(draftId) => `https://superdesign.dev/preview/draft/${draftId}`
canvasUrlFor(teamId, projectId) => `https://superdesign.dev/teams/${teamId}/projects/${projectId}`
renderCreateProject/renderCreateDraft default output: fields { label:'canvas', value:projectUrl }, { label:'preview', value:previewUrl }
renderIterateDraft/renderExecuteFlow default output line: `canvas: ${r.projectUrl}`
live view: const urlWithLive = `${project.projectUrl}?live=1`
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ℹ️ `skills/superdesign/SKILL.md:33` - The Step 1 &#39;no meaningful codebase&#39; heuristic (SKILL.md:29-33) only scans for framework/UI-library deps in package.json and for `.tsx/.jsx/.vue/.svelte` sources. A vanilla static frontend (e.g. root `index.html` + `style.css`, no package.json, no src/ dir) satisfies all three &#39;no codebase&#39; conditions and gets routed to the BRAND-NEW-PROJECT path — skipping repo init even though there is real existing UI to analyze and faithfully reproduce. Consider adding `.html`/`.css` (or a root-level HTML scan) to the frontend-source check.

🔧 Fix: Count vanilla html/css as real codebase in Step 1 check
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`npx --yes @superdesign/cli@latest --version` → 0.5.1 (confirms @latest surface)</code>
- <code>`npm pack @superdesign/cli@latest` + grep of dist/index.js for `canvasUrlFor`/`previewUrlFor`/`?live=1`/`canvas:`/`preview:` — verified documented URL shapes and default-output link surfacing against published source</code>
- `Inspected renderCreateProject/renderCreateDraft/renderIterateDraft/renderExecuteFlow default (non-json) render blocks for canvas/preview fields`
- <code>grep of SKILL.md section headers + SUPERDESIGN.md cross-references (`SOP: BRAND NEW PROJECT`, `SKILL.md Step 1`) to confirm resolvable references</code>
- `em-dash scan of AGENTS.md (none, matching plain-dash idiom)`
- `Rendered SKILL.md to HTML via marked and captured full-page screenshot with chrome-devtools-axi`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
