### PR TITLE
Add graphic workflow (fixed-canvas graphics with agent-generated key visuals)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .claude
 .DS_Store
 dist/
+.superdesign/
+assets/generated/

--- a/skills/superdesign/SKILL.md
+++ b/skills/superdesign/SKILL.md
@@ -13,7 +13,7 @@ Superdesign helps you (1) find design inspirations/styles and (2) generate/itera
 2. **Help me design X** (feature/page/flow)
 3. **Set design system**
 4. **Help me improve design of X**
-5. **Make a poster / marketing asset** (flyer, cover art, social feed post, story, channel cover, thumbnail, ad creative) — a static artwork, not a page. Skip repo init/analysis; read `references/POSTER.md` relative to this `SKILL.md` and follow it (you generate the key visual with your own image tool, upload it, then compose the artwork on a fixed canvas; platform dimension table included).
+5. **Make a poster / marketing asset** (flyer, cover art, social feed post, story, channel cover, thumbnail, ad creative) — a static artwork, not a page. Skip repo init/analysis; read `references/GRAPHIC.md` relative to this `SKILL.md` and follow it (you generate the key visual with your own image tool, upload it, then compose the artwork on a fixed canvas; platform dimension table included).
 
 # Step 0 — Environment preflight (BEFORE any CLI step)
 
@@ -94,7 +94,7 @@ npx --yes @superdesign/cli@latest create-component --project-id <id> --name "Nav
 npx --yes @superdesign/cli@latest update-component --component-id <id> --html-file .superdesign/tmp/navbar.html
 npx --yes @superdesign/cli@latest list-components --project-id <id>
 npx --yes @superdesign/cli@latest upload-asset ./key-visual.png --project-id <id>
-npx --yes @superdesign/cli@latest create-design-draft --project-id <id> --title "Launch Poster" --kind poster --width 900 --height 1200 -p "Design a static poster..."
+npx --yes @superdesign/cli@latest create-design-draft --project-id <id> --title "Launch Poster" --kind graphic --width 900 --height 1200 -p "Design a static poster..."
 ```
 
 Each item in the `execute-flow-pages` `--pages` array generates one new page styled after the source draft (1-10 pages per call).

--- a/skills/superdesign/SKILL.md
+++ b/skills/superdesign/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: superdesign
-description: "Design or redesign frontend UI with the Superdesign canvas. Use for design-system extraction, faithful UI reproduction, visual variants, reusable design components, and multi-page flows. Do not use for implementation-only tasks that require no design exploration."
+description: "Design or redesign frontend UI with the Superdesign canvas. Use for design-system extraction, faithful UI reproduction, visual variants, reusable design components, multi-page flows, and static posters/flyers/cover art/social graphics composed on a fixed canvas. Do not use for implementation-only tasks that require no design exploration."
 ---
 
 Superdesign helps you (1) find design inspirations/styles and (2) generate/iterate design drafts on an infinite canvas.
@@ -13,6 +13,7 @@ Superdesign helps you (1) find design inspirations/styles and (2) generate/itera
 2. **Help me design X** (feature/page/flow)
 3. **Set design system**
 4. **Help me improve design of X**
+5. **Make a poster / marketing asset** (flyer, cover art, social feed post, story, channel cover, thumbnail, ad creative) — a static artwork, not a page. Skip repo init/analysis; read `references/POSTER.md` relative to this `SKILL.md` and follow it (you generate the key visual with your own image tool, upload it, then compose the artwork on a fixed canvas; platform dimension table included).
 
 # Step 0 — Environment preflight (BEFORE any CLI step)
 
@@ -92,6 +93,8 @@ npx --yes @superdesign/cli@latest execute-flow-pages --draft-id <id> --pages '[{
 npx --yes @superdesign/cli@latest create-component --project-id <id> --name "NavBar" --html-file .superdesign/tmp/navbar.html --props '[{"name":"activeItem","type":"string","defaultValue":"home"}]'
 npx --yes @superdesign/cli@latest update-component --component-id <id> --html-file .superdesign/tmp/navbar.html
 npx --yes @superdesign/cli@latest list-components --project-id <id>
+npx --yes @superdesign/cli@latest upload-asset ./key-visual.png --project-id <id>
+npx --yes @superdesign/cli@latest create-design-draft --project-id <id> --title "Launch Poster" --kind poster --width 900 --height 1200 -p "Design a static poster..."
 ```
 
 Each item in the `execute-flow-pages` `--pages` array generates one new page styled after the source draft (1-10 pages per call).

--- a/skills/superdesign/references/GRAPHIC.md
+++ b/skills/superdesign/references/GRAPHIC.md
@@ -1,17 +1,17 @@
-# Poster Generation Workflow
+# Graphic Generation Workflow (posters, covers, social & marketing assets)
 
 Use this workflow when the user asks for a **static poster-like artwork** — poster, flyer, cover art, album/book cover, event visual, social media graphic, banner artwork — rather than a web page or app screen. It replaces the EXISTING UI / BRAND NEW PROJECT SOPs; everything else in `SUPERDESIGN.md` (CLI setup, login, canvas links, command contract) still applies.
 
-Core idea: **you** produce the key visual with your own image-generation tool, upload it to Superdesign, and let Superdesign compose the poster as pixel-perfect HTML on a fixed canvas. Text is always rendered by the poster layer, never baked into images — that is what keeps posters sharp, editable, and iterable.
+Core idea: **you** produce the key visual with your own image-generation tool, upload it to Superdesign, and let Superdesign compose the graphic as pixel-perfect HTML on a fixed canvas. Text is always rendered by the HTML layer, never baked into images — that is what keeps graphics sharp, editable, and iterable.
 
-A poster lives in a project like any draft. Reuse the current project or `create-project --title "<topic> Posters"` first.
+A graphic lives in a project like any draft. Reuse the current project or `create-project --title "<topic> Graphics"` first.
 
 ## Overview
 
 1. Confirm the brief (copy, canvas, layout, style, asset plan) — ONE confirmation round
 2. Generate the key visual with your own image tool (only if the layout needs one)
 3. `upload-asset` → public URL
-4. `create-design-draft --kind poster` with the assembled prompt
+4. `create-design-draft --kind graphic` with the assembled prompt
 5. Share the canvas link, iterate on feedback
 
 ## Step 1 — Confirm the brief (one round, not three)
@@ -101,7 +101,7 @@ Only for layouts that need one (see menu). Rules for the image prompt:
 - **ABSOLUTELY NO TEXT in the image**: no letters, words, logos, watermarks, or UI. Text belongs to the poster layer.
 - Use the aspect from the canvas table.
 
-Show the generated image to the user and offer one regenerate/adjust round (more only if they ask). While looking at the image, write yourself a short **visual description** — dominant colors (approximate hex), composition, where the negative space is. You will paste this into the poster prompt so the layout generator can match colors and place text without seeing the image.
+Show the generated image to the user and offer one regenerate/adjust round (more only if they ask). While looking at the image, write yourself a short **visual description** — dominant colors (approximate hex), composition, where the negative space is. You will paste this into the graphic prompt so the layout generator can match colors and place text without seeing the image.
 
 If the user provides their own image file, skip generation and continue with upload.
 
@@ -111,20 +111,20 @@ If the user provides their own image file, skip generation and continue with upl
 npx --yes @superdesign/cli@latest upload-asset <file> --project-id <projectId>
 ```
 
-Accepts png/jpeg/webp/gif up to 10MB and prints a public `url` — that URL is what goes into the poster prompt. Upload each asset once and reuse the URL across drafts/iterations. The asset also appears on the project canvas as an image node next to the posters (pass `--no-canvas` to skip that).
+Accepts png/jpeg/webp/gif up to 10MB and prints a public `url` — that URL is what goes into the graphic prompt. Upload each asset once and reuse the URL across drafts/iterations. The asset also appears on the project canvas as an image node next to the graphic drafts (pass `--no-canvas` to skip that).
 
-## Step 4 — Generate the poster
+## Step 4 — Generate the graphic
 
 ```bash
 npx --yes @superdesign/cli@latest create-design-draft --project-id <id> \
-  --title "<Poster title>" --kind poster --width <W> --height <H> \
+  --title "<Poster title>" --kind graphic --width <W> --height <H> \
   -p "<assembled prompt>"
 ```
 
 Assemble the single `-p` prompt from the confirmed brief:
 
 ```text
-Design a static poster. The canvas is EXACTLY <W>x<H>px — nothing may overflow or scroll.
+Design a static graphic. The canvas is EXACTLY <W>x<H>px — nothing may overflow or scroll.
 
 LAYOUT — <layout name>: <composition skeleton from the menu, expanded with your art direction>
 
@@ -141,14 +141,14 @@ STYLE: <style adjectives, palette, font character (e.g. heavy grotesque headline
 
 Omit the KEY VISUAL block for asset-less layouts.
 
-**Fallback**: if the CLI rejects `--kind` as an unknown option (older CLI), re-run without it and append to the prompt: "This is a POSTER, not a web page: no responsive prefixes (sm:/md:/lg:), no scrolling, no navigation bars, buttons, or forms."
+**Fallback**: if the CLI rejects `--kind` as an unknown option (older CLI), re-run without it and append to the prompt: "This is a static fixed-canvas GRAPHIC, not a web page: no responsive prefixes (sm:/md:/lg:), no scrolling, no navigation bars, buttons, or forms."
 
 ## Step 5 — Review & iterate
 
 - Give the user the `canvas` link from the command output (and the `preview` link).
-- Iterate with `iterate-design-draft` as usual — drafts created with `--kind poster` stay in poster mode server-side, so plain instructions like "make the headline bigger" are safe. If you used the no-`--kind` fallback, restate the poster constraints in EVERY iterate prompt.
+- Iterate with `iterate-design-draft` as usual — drafts created with `--kind graphic` stay in graphic mode server-side, so plain instructions like "make the headline bigger" are safe. If you used the no-`--kind` fallback, restate the graphic constraints in EVERY iterate prompt.
 - `--mode branch` works well for exploring 2-3 poster directions from the same brief and asset.
 
-## Poster series (multiple posters)
+## Series (multiple graphics)
 
 Never use flow pages for posters. One poster = one `create-design-draft` call; for a series, keep the copy per poster but reuse the same style direction and asset URLs so the set stays coherent, and generate the shared key visual once before the first poster.

--- a/skills/superdesign/references/POSTER.md
+++ b/skills/superdesign/references/POSTER.md
@@ -111,7 +111,7 @@ If the user provides their own image file, skip generation and continue with upl
 npx --yes @superdesign/cli@latest upload-asset <file> --project-id <projectId>
 ```
 
-Accepts png/jpeg/webp/gif up to 10MB and prints a public `url` — that URL is what goes into the poster prompt. Upload each asset once and reuse the URL across drafts/iterations.
+Accepts png/jpeg/webp/gif up to 10MB and prints a public `url` — that URL is what goes into the poster prompt. Upload each asset once and reuse the URL across drafts/iterations. The asset also appears on the project canvas as an image node next to the posters (pass `--no-canvas` to skip that).
 
 ## Step 4 — Generate the poster
 

--- a/skills/superdesign/references/POSTER.md
+++ b/skills/superdesign/references/POSTER.md
@@ -1,0 +1,154 @@
+# Poster Generation Workflow
+
+Use this workflow when the user asks for a **static poster-like artwork** — poster, flyer, cover art, album/book cover, event visual, social media graphic, banner artwork — rather than a web page or app screen. It replaces the EXISTING UI / BRAND NEW PROJECT SOPs; everything else in `SUPERDESIGN.md` (CLI setup, login, canvas links, command contract) still applies.
+
+Core idea: **you** produce the key visual with your own image-generation tool, upload it to Superdesign, and let Superdesign compose the poster as pixel-perfect HTML on a fixed canvas. Text is always rendered by the poster layer, never baked into images — that is what keeps posters sharp, editable, and iterable.
+
+A poster lives in a project like any draft. Reuse the current project or `create-project --title "<topic> Posters"` first.
+
+## Overview
+
+1. Confirm the brief (copy, canvas, layout, style, asset plan) — ONE confirmation round
+2. Generate the key visual with your own image tool (only if the layout needs one)
+3. `upload-asset` → public URL
+4. `create-design-draft --kind poster` with the assembled prompt
+5. Share the canvas link, iterate on feedback
+
+## Step 1 — Confirm the brief (one round, not three)
+
+Draft a concrete proposal yourself, then confirm it with the user in a SINGLE round using your question/confirmation mechanism. Skip confirmation entirely when the user already gave full specs or says to generate directly.
+
+Cover these five items:
+
+- **Purpose**: what the poster announces/sells and where it will be shown.
+- **Verbatim copy**: the exact headline, subhead, info lines (date/venue/price/URL), and footer. Write them out and get them locked — the generator reproduces these strings EXACTLY, so typos and missing lines here become typos on the poster.
+- **Canvas**: pick from the presets below (user-given dimensions always win).
+- **Layout**: recommend ONE from the menu with a one-line reason; let the user swap.
+- **Style + asset plan**: 2-3 style adjectives with a rough palette, and the asset plan implied by the layout (AI-generate / user provides a file / no imagery).
+
+### Canvas presets
+
+| Use case                     | Canvas (`--width`x`--height`) | Image-gen aspect for assets |
+| ---------------------------- | ----------------------------- | --------------------------- |
+| Portrait poster / print-like | 900x1200                      | portrait (e.g. 1024x1536)   |
+| Square social post           | 1080x1080                     | square (1024x1024)          |
+| Story / vertical social      | 1080x1920                     | portrait (1024x1536)        |
+| Landscape banner / header    | 1500x750                      | landscape (1536x1024)       |
+
+Image tools only offer fixed size steps — match the nearest **aspect**, not exact pixels; the poster layer crops with `object-cover`.
+
+### Platform-specific marketing assets
+
+When the poster is a marketing asset for a specific platform (feed post, story, cover, thumbnail, ad creative), use the exact platform dimension instead of the generic presets — and MUST confirm the dimension with the user before creating; do NOT assume it.
+
+| Category  | Platform               | Asset Type            | Aspect Ratio | Recommended Size (px) |
+| --------- | ---------------------- | --------------------- | ------------ | --------------------- |
+| Feed      | Instagram              | Feed Post (Square)    | 1:1          | 1080 × 1080 (default) |
+| Feed      | Instagram              | Feed Post (Portrait)  | 4:5          | 1080 × 1350           |
+| Feed      | Instagram              | Feed Post (Landscape) | 1.91:1       | 1080 × 566            |
+| Feed      | Facebook               | Feed Post             | 1.91:1       | 1200 × 630            |
+| Feed      | LinkedIn               | Feed Post             | 1:1          | 1200 × 1200 (default) |
+| Feed      | LinkedIn               | Feed Post (Landscape) | 1.91:1       | 1200 × 627            |
+| Feed      | X / Twitter            | Post Image            | 16:9         | 1200 × 675            |
+| Feed      | Threads                | Post Image            | 1:1          | 1080 × 1080           |
+| Vertical  | Instagram              | Story                 | 9:16         | 1080 × 1920           |
+| Vertical  | Instagram              | Reel Cover            | 9:16         | 1080 × 1920           |
+| Vertical  | TikTok                 | Video / Cover         | 9:16         | 1080 × 1920           |
+| Vertical  | YouTube                | Shorts                | 9:16         | 1080 × 1920           |
+| Carousel  | Instagram              | Carousel Slide        | 4:5          | 1080 × 1350           |
+| Carousel  | LinkedIn               | Carousel (PDF slides) | 1:1          | 1080 × 1080           |
+| Cover     | LinkedIn               | Profile Cover         | 4:1          | 1584 × 396            |
+| Cover     | Facebook               | Page Cover            | ~1.9:1       | 1640 × 856            |
+| Cover     | X / Twitter            | Header                | 3:1          | 1500 × 500            |
+| Cover     | YouTube                | Channel Art           | 16:9         | 2560 × 1440           |
+| Thumbnail | YouTube                | Video Thumbnail       | 16:9         | 1280 × 720            |
+| Ads       | Google Display Ads     | Medium Rectangle      | 4:3          | 300 × 250             |
+| Ads       | Google Display Ads     | Large Rectangle       |              | 336 × 280             |
+| Ads       | Google Display Ads     | Leaderboard           |              | 728 × 90              |
+| Ads       | Google Display Ads     | Large Leaderboard     |              | 970 × 90              |
+| Ads       | Google Display Ads     | Billboard             |              | 970 × 250             |
+| Ads       | Google Display Ads     | Half Page             |              | 300 × 600             |
+| Ads       | Google Display Ads     | Large Mobile Banner   |              | 320 × 100             |
+| Ads       | Google Display Ads     | Mobile Banner         |              | 320 × 50              |
+| Ads       | Google Display Ads     | Square                |              | 250 × 250             |
+| Ads       | Google Display Ads     | Small Square          |              | 200 × 200             |
+| Ads       | Google Performance Max | Landscape Image       | 1.91:1       | 1200 × 628            |
+| Ads       | Google Performance Max | Square Image          | 1:1          | 1200 × 1200           |
+| Ads       | Google Performance Max | Portrait Image        | 4:5          | 960 × 1200            |
+| Ads       | Google App Ads         | App Landscape         | 1.91:1       | 1200 × 628            |
+| Ads       | Google App Ads         | App Square            | 1:1          | 1200 × 1200           |
+
+Small ad units (leaderboards, banners, squares under ~400px) are micro-layouts: default to the type-hero or split layout at reduced scale, skip generated key visuals below 300px on the short side, and keep copy to a headline + CTA.
+
+### Layout menu (pick exactly one)
+
+| Layout             | Composition skeleton                                                                                          | Whitespace                 | Key visual                                 |
+| ------------------ | ------------------------------------------------------------------------------------------------------------- | -------------------------- | ------------------------------------------ |
+| **type-hero**      | Giant headline dominates (~8-20% of canvas height), tight leading; small info block + footer on a strict grid | 60-70%                     | none — typography IS the poster            |
+| **full-bleed**     | Key visual fills the whole canvas; text overlaid on a darkened/tinted zone or gradient scrim                  | 30-40% clear zone for text | background image (no text in it)           |
+| **split**          | Canvas divided (top/bottom or left/right ~55/45): one zone pure imagery, the other a clean info panel         | 40-50% in info zone        | subject image (product, artwork, portrait) |
+| **list**           | Title band + 3-7 numbered/bulleted entries on an aligned grid; compact footer                                 | 20-35%                     | optional small accent image or none        |
+| **centered-badge** | Everything centered and symmetric like a certificate/invitation: ornament, headline, details stacked          | 50-60%                     | optional decorative motif                  |
+
+Routing hints: slogan/quote/announcement → type-hero; concert/film/album/atmosphere → full-bleed; product/exhibition piece → split; agenda/ranking/menu → list; invitation/award → centered-badge.
+
+## Step 2 — Key visual (your own image tool)
+
+Only for layouts that need one (see menu). Rules for the image prompt:
+
+- Subject + composition first, then style and palette (carry the confirmed style adjectives; name 2-3 hex-ish colors).
+- Tell the model to **leave clear negative space** where the layout will place the headline (e.g. "upper third clean and uncluttered").
+- **ABSOLUTELY NO TEXT in the image**: no letters, words, logos, watermarks, or UI. Text belongs to the poster layer.
+- Use the aspect from the canvas table.
+
+Show the generated image to the user and offer one regenerate/adjust round (more only if they ask). While looking at the image, write yourself a short **visual description** — dominant colors (approximate hex), composition, where the negative space is. You will paste this into the poster prompt so the layout generator can match colors and place text without seeing the image.
+
+If the user provides their own image file, skip generation and continue with upload.
+
+## Step 3 — Upload the asset
+
+```bash
+npx --yes @superdesign/cli@latest upload-asset <file> --project-id <projectId>
+```
+
+Accepts png/jpeg/webp/gif up to 10MB and prints a public `url` — that URL is what goes into the poster prompt. Upload each asset once and reuse the URL across drafts/iterations.
+
+## Step 4 — Generate the poster
+
+```bash
+npx --yes @superdesign/cli@latest create-design-draft --project-id <id> \
+  --title "<Poster title>" --kind poster --width <W> --height <H> \
+  -p "<assembled prompt>"
+```
+
+Assemble the single `-p` prompt from the confirmed brief:
+
+```text
+Design a static poster. The canvas is EXACTLY <W>x<H>px — nothing may overflow or scroll.
+
+LAYOUT — <layout name>: <composition skeleton from the menu, expanded with your art direction>
+
+COPY (reproduce these strings EXACTLY — no rewording, no additions):
+- Headline: "<...>"
+- Subhead: "<...>"
+- Info: <date / venue / price / URL lines>
+- Footer: "<...>"
+
+KEY VISUAL: use <asset url> as the <background / subject / accent per layout> — embed via <img> or CSS background-image with object-cover, never distort. The image is: <your visual description: palette hexes, composition, where the negative space is>. Match the poster's remaining colors and text placement to it.
+
+STYLE: <style adjectives, palette, font character (e.g. heavy grotesque headline + light mono captions)>.
+```
+
+Omit the KEY VISUAL block for asset-less layouts.
+
+**Fallback**: if the CLI rejects `--kind` as an unknown option (older CLI), re-run without it and append to the prompt: "This is a POSTER, not a web page: no responsive prefixes (sm:/md:/lg:), no scrolling, no navigation bars, buttons, or forms."
+
+## Step 5 — Review & iterate
+
+- Give the user the `canvas` link from the command output (and the `preview` link).
+- Iterate with `iterate-design-draft` as usual — drafts created with `--kind poster` stay in poster mode server-side, so plain instructions like "make the headline bigger" are safe. If you used the no-`--kind` fallback, restate the poster constraints in EVERY iterate prompt.
+- `--mode branch` works well for exploring 2-3 poster directions from the same brief and asset.
+
+## Poster series (multiple posters)
+
+Never use flow pages for posters. One poster = one `create-design-draft` call; for a series, keep the copy per poster but reuse the same style direction and asset URLs so the set stays coherent, and generate the shared key visual once before the first poster.

--- a/skills/superdesign/references/SUPERDESIGN.md
+++ b/skills/superdesign/references/SUPERDESIGN.md
@@ -533,7 +533,7 @@ Every command supports `--json` for the full machine-readable payload; the defau
   - Only use this for creating purely new design from scratch.
   - --device custom requires both --width and --height (min 20px each). Providing --width/--height auto-sets --device to custom.
   - --kind poster switches generation to the fixed-canvas poster branch (static artwork, no responsive layout) and keeps iterations in poster mode; pair it with --width/--height. See `references/POSTER.md`.
-- upload-asset: required `<file>` positional (png/jpeg/webp/gif, max 10MB) and `--project-id`; optional `--json`. Uploads a project image asset and returns a public `url` to reference from create/iterate prompts (e.g. a poster key visual).
+- upload-asset: required `<file>` positional (png/jpeg/webp/gif, max 10MB) and `--project-id`; optional `--no-canvas`, `--json`. Uploads a project image asset and returns a public `url` to reference from create/iterate prompts (e.g. a poster key visual). By default the asset is also placed on the project canvas as an image node (response includes its `nodeId`); pass `--no-canvas` to skip.
 - revert-design-draft: required `--draft-id`, `--to-version <n>`; optional `--json`. Restores a prior version as the current head with NO generation; reversible (the current head is snapshotted into history first). Discover version numbers via `get-design`.
 - execute-flow-pages: required `--draft-id`, `--pages`; optional `--context`, `--context-file` (one or more paths; supports `path:startLine:endLine`), `--model`, `--json`
 - get-design: required `--draft-id`; optional `--json`, `--output <path>`

--- a/skills/superdesign/references/SUPERDESIGN.md
+++ b/skills/superdesign/references/SUPERDESIGN.md
@@ -31,6 +31,7 @@ These files are pre-analyzed context and MUST be read every time before any desi
 Superdesign needs ALL UI code for accurate reproduction. Include every piece of visual code — JSX/template, className, inline styles, props interfaces, CSS. Only strip pure business logic that has zero visual impact.
 
 **Strip logic code, keep happy-path UI.** That's it.
+
 - Remove: data fetching, event handlers, API calls, auth checks, loading/error/empty guard returns
 - Keep: all JSX, styles, className, props, CSS, config — the complete happy-path UI as-is
 
@@ -64,6 +65,7 @@ If `.superdesign/init/pages.md` exists, use it as the starting point — it pre-
 
 **⚠️ 1000+ LINE FILE RULE (MANDATORY):**
 Any file exceeding ~1000 lines MUST use line ranges — no exceptions. Extract only the sections relevant to the target page:
+
 - **Large CSS files (1000+ lines)**: extract ONLY the selectors/variables actually used by the target page's components. Trace each className → find its CSS definition lines → include only those sections.
 - **Large component files with many variants**: extract ONLY the variant/branch being used on the target page, skip unused variants.
 - **Large config files**: extract only the relevant config sections.
@@ -114,22 +116,23 @@ After requirements gathering, extract reusable components so they are available 
    a. Read the React source code from the path listed in `extractable-components.md`
    b. Convert to Petite-Vue HTML template following the **Petite-Vue Template Spec** below
    c. Create `.superdesign/tmp/` if needed. Ensure `.superdesign/tmp/` is ignored by the project's `.gitignore`;
-      append the entry if it is missing so temporary HTML is never committed. Then write the HTML to a file there.
+   append the entry if it is missing so temporary HTML is never committed. Then write the HTML to a file there.
    d. Create the component:
-      ```
-      npx --yes @superdesign/cli@latest create-component --project-id <id> \
-        --name "NavBar" \
-        --html-file .superdesign/tmp/navbar-component.html \
-        --description "Main navigation bar" \
-        --props '[{"name":"activeItem","type":"string","defaultValue":"home"}]'
-      ```
-      The default output returns the new `componentId` plus `help[]` next-step hints — add `--json` only if you need the full machine payload.
+   ```
+   npx --yes @superdesign/cli@latest create-component --project-id <id> \
+     --name "NavBar" \
+     --html-file .superdesign/tmp/navbar-component.html \
+     --description "Main navigation bar" \
+     --props '[{"name":"activeItem","type":"string","defaultValue":"home"}]'
+   ```
+   The default output returns the new `componentId` plus `help[]` next-step hints — add `--json` only if you need the full machine payload.
 5. **Focus on layout components first** (NavBar, Sidebar, Footer, Header) — these appear on every page and benefit most from extraction.
 6. **Skip basic UI primitives** (Button, Input, Card) — these are too simple to warrant extraction and are better as inline HTML in drafts.
 
 After extraction, proceed to Step 3. The draft generation agent will automatically see these components via `buildComponentContext()` and use `<sd-component>` tags in the generated HTML.
 
 **When to skip Step 2.5:**
+
 - Brand new projects with no existing UI components
 - When the user explicitly says they don't want component extraction
 - When `extractable-components.md` doesn't exist or lists no layout components
@@ -246,6 +249,7 @@ Step 3 — Design in Superdesign:
 ## DESIGN SYSTEM SETUP
 
 Design system should provides full context across:
+
 - Product context, key pages & architecture, key features, JTBD
 - Branding & styling: color, font, spacing, shadow, layout structure, etc.
 - motion/animation patterns
@@ -409,6 +413,7 @@ Multiple ranges from the same file are automatically merged into a single contex
 When converting React components to Petite-Vue HTML templates for `create-component`:
 
 ### What to HARDCODE in the template (NOT props):
+
 - Icon names and SVG markup
 - Text labels, menu item names
 - Image sources and alt text
@@ -417,12 +422,14 @@ When converting React components to Petite-Vue HTML templates for `create-compon
 - Color values, font sizes, spacing
 
 ### What to EXTRACT as props (ONLY these categories):
+
 - **Active state**: `activeItem`, `isActive`, `currentTab` — indicates which page/section is selected
 - **Navigation URLs**: `homeHref`, `searchHref`, `profileHref` — link destinations
 - **Conditional visibility**: `showNotification`, `showBadge`, `isExpanded` — toggle elements
 - **Dynamic counts**: `badgeCount`, `notificationCount` — numeric values that change
 
 ### Allowed Petite-Vue syntax:
+
 - `{{ propName }}` — text interpolation
 - `:href="propName"` — attribute binding
 - `v-if="propName"` / `v-show="propName"` — conditional rendering
@@ -430,6 +437,7 @@ When converting React components to Petite-Vue HTML templates for `create-compon
 - `@click="$emit('name', payload)"` — event emission
 
 ### NOT allowed:
+
 - `v-for` for navigation items (hardcode each item instead)
 - `v-model` (no two-way binding)
 - `v-html` (no raw HTML injection)
@@ -438,6 +446,7 @@ When converting React components to Petite-Vue HTML templates for `create-compon
 ### Every prop MUST have a non-empty `defaultValue`.
 
 ### Output requirements:
+
 - Valid HTML with Tailwind CSS classes
 - Replace all CSS modules / styled-components with Tailwind utilities or inline styles
 - Use Lucide icon CDN or inline SVGs for icons
@@ -446,77 +455,63 @@ When converting React components to Petite-Vue HTML templates for `create-compon
 ### Example conversion:
 
 **React source:**
+
 ```tsx
-function NavBar({ activeItem = 'home' }) {
+function NavBar({ activeItem = "home" }) {
   return (
     <nav className="flex items-center gap-4 px-6 py-3 bg-white border-b">
       <Logo />
-      <Link to="/" className={cn("text-sm", activeItem === 'home' && "font-bold")}>Home</Link>
-      <Link to="/explore" className={cn("text-sm", activeItem === 'explore' && "font-bold")}>Explore</Link>
+      <Link
+        to="/"
+        className={cn("text-sm", activeItem === "home" && "font-bold")}
+      >
+        Home
+      </Link>
+      <Link
+        to="/explore"
+        className={cn("text-sm", activeItem === "explore" && "font-bold")}
+      >
+        Explore
+      </Link>
     </nav>
   );
 }
 ```
 
 **Petite-Vue template:**
+
 ```html
 <nav class="flex items-center gap-4 px-6 py-3 bg-white border-b">
   <svg class="w-6 h-6"><!-- actual logo SVG --></svg>
-  <a :href="homeHref" :class="{ 'font-bold': activeItem === 'home' }" class="text-sm">Home</a>
-  <a :href="exploreHref" :class="{ 'font-bold': activeItem === 'explore' }" class="text-sm">Explore</a>
+  <a
+    :href="homeHref"
+    :class="{ 'font-bold': activeItem === 'home' }"
+    class="text-sm"
+    >Home</a
+  >
+  <a
+    :href="exploreHref"
+    :class="{ 'font-bold': activeItem === 'explore' }"
+    class="text-sm"
+    >Explore</a
+  >
 </nav>
 ```
 
 **Props:**
+
 ```json
 [
-  {"name": "activeItem", "type": "string", "defaultValue": "home"},
-  {"name": "homeHref", "type": "string", "defaultValue": "#"},
-  {"name": "exploreHref", "type": "string", "defaultValue": "#"}
+  { "name": "activeItem", "type": "string", "defaultValue": "home" },
+  { "name": "homeHref", "type": "string", "defaultValue": "#" },
+  { "name": "exploreHref", "type": "string", "defaultValue": "#" }
 ]
 ```
 
 ---
 
 <marketing_assets_dimension_guidelines>
-| Category  | Platform               | Asset Type            | Aspect Ratio | Recommended Size (px) |
-| --------- | ---------------------- | --------------------- | ------------ | --------------------- |
-| Feed      | Instagram              | Feed Post (Square)    | 1:1          | 1080 × 1080 (default) |
-| Feed      | Instagram              | Feed Post (Portrait)  | 4:5          | 1080 × 1350           |
-| Feed      | Instagram              | Feed Post (Landscape) | 1.91:1       | 1080 × 566            |
-| Feed      | Facebook               | Feed Post             | 1.91:1       | 1200 × 630            |
-| Feed      | LinkedIn               | Feed Post             | 1:1          | 1200 × 1200 (default) |
-| Feed      | LinkedIn               | Feed Post (Landscape) | 1.91:1       | 1200 × 627            |
-| Feed      | X / Twitter            | Post Image            | 16:9         | 1200 × 675            |
-| Feed      | Threads                | Post Image            | 1:1          | 1080 × 1080           |
-| Vertical  | Instagram              | Story                 | 9:16         | 1080 × 1920           |
-| Vertical  | Instagram              | Reel Cover            | 9:16         | 1080 × 1920           |
-| Vertical  | TikTok                 | Video / Cover         | 9:16         | 1080 × 1920           |
-| Vertical  | YouTube                | Shorts                | 9:16         | 1080 × 1920           |
-| Carousel  | Instagram              | Carousel Slide        | 4:5          | 1080 × 1350           |
-| Carousel  | LinkedIn               | Carousel (PDF slides) | 1:1          | 1080 × 1080           |
-| Cover     | LinkedIn               | Profile Cover         | 4:1          | 1584 × 396            |
-| Cover     | Facebook               | Page Cover            | ~1.9:1       | 1640 × 856            |
-| Cover     | X / Twitter            | Header                | 3:1          | 1500 × 500            |
-| Cover     | YouTube                | Channel Art           | 16:9         | 2560 × 1440           |
-| Thumbnail | YouTube                | Video Thumbnail       | 16:9         | 1280 × 720            |
-| Ads       | Google Display Ads     | Medium Rectangle      | 4:3          | 300 × 250             |
-| Ads       | Google Display Ads     | Large Rectangle       | 336 × 280    |                       |
-| Ads       | Google Display Ads     | Leaderboard           | 728 × 90     |                       |
-| Ads       | Google Display Ads     | Large Leaderboard     | 970 × 90     |                       |
-| Ads       | Google Display Ads     | Billboard             | 970 × 250    |                       |
-| Ads       | Google Display Ads     | Half Page             | 300 × 600    |                       |
-| Ads       | Google Display Ads     | Large Mobile Banner   | 320 × 100    |                       |
-| Ads       | Google Display Ads     | Mobile Banner         | 320 × 50     |                       |
-| Ads       | Google Display Ads     | Square                | 250 × 250    |                       |
-| Ads       | Google Display Ads     | Small Square          | 200 × 200    |                       |
-| Ads       | Google Performance Max | Landscape Image       | 1.91:1       | 1200 × 628            |
-| Ads       | Google Performance Max | Square Image          | 1:1          | 1200 × 1200           |
-| Ads       | Google Performance Max | Portrait Image        | 4:5          | 960 × 1200            |
-| Ads       | Google App Ads         | App Landscape         | 1.91:1       | 1200 × 628            |
-| Ads       | Google App Ads         | App Square            | 1:1          | 1200 × 1200           |
-
-For marketing assets, MUST confirm with the user the dimension before creating, do NOT assume the dimension
+Marketing assets (feed posts, stories, covers, thumbnails, ad creatives) are static fixed-canvas artworks: generate them via the poster workflow in `references/POSTER.md` (`--kind poster`), which carries the platform dimension table. MUST confirm the dimension with the user before creating — do NOT assume it.
 </marketing_assets_dimension_guidelines>
 
 ---
@@ -532,11 +527,13 @@ Every command supports `--json` for the full machine-readable payload; the defau
   - replace: use exactly one `-p`; do not use `--count`
   - `--from-version <n>`: iterate from a specific historical version instead of the current head (discover version numbers via `get-design`)
   - `--device <mobile|tablet|desktop|custom>` / `--width <pixels>` / `--height <pixels>`: OVERRIDE the viewport. Defaults to the source draft's device — omit unless deliberately changing it. `--width`/`--height` require `--device custom`.
-- create-design-draft: required `--project-id`, `--title`, and `-p` (SINGLE prompt only); optional `--device <mobile|tablet|desktop|custom>` (default: desktop), `--width <pixels>`, `--height <pixels>`, `--context-file` (one or more paths; supports `path:startLine:endLine`), `--model`, `--user-request <text>`, `--json`
+- create-design-draft: required `--project-id`, `--title`, and `-p` (SINGLE prompt only); optional `--device <mobile|tablet|desktop|custom>` (default: desktop), `--width <pixels>`, `--height <pixels>`, `--kind <page|poster>` (default: page), `--context-file` (one or more paths; supports `path:startLine:endLine`), `--model`, `--user-request <text>`, `--json`
   - ⚠️ ONLY accepts ONE -p flag. Multiple -p flags will silently drop all but the last one.
   - Combine all design directions into a single -p string.
   - Only use this for creating purely new design from scratch.
   - --device custom requires both --width and --height (min 20px each). Providing --width/--height auto-sets --device to custom.
+  - --kind poster switches generation to the fixed-canvas poster branch (static artwork, no responsive layout) and keeps iterations in poster mode; pair it with --width/--height. See `references/POSTER.md`.
+- upload-asset: required `<file>` positional (png/jpeg/webp/gif, max 10MB) and `--project-id`; optional `--json`. Uploads a project image asset and returns a public `url` to reference from create/iterate prompts (e.g. a poster key visual).
 - revert-design-draft: required `--draft-id`, `--to-version <n>`; optional `--json`. Restores a prior version as the current head with NO generation; reversible (the current head is snapshotted into history first). Discover version numbers via `get-design`.
 - execute-flow-pages: required `--draft-id`, `--pages`; optional `--context`, `--context-file` (one or more paths; supports `path:startLine:endLine`), `--model`, `--json`
 - get-design: required `--draft-id`; optional `--json`, `--output <path>`

--- a/skills/superdesign/references/SUPERDESIGN.md
+++ b/skills/superdesign/references/SUPERDESIGN.md
@@ -511,7 +511,7 @@ function NavBar({ activeItem = "home" }) {
 ---
 
 <marketing_assets_dimension_guidelines>
-Marketing assets (feed posts, stories, covers, thumbnails, ad creatives) are static fixed-canvas artworks: generate them via the poster workflow in `references/POSTER.md` (`--kind poster`), which carries the platform dimension table. MUST confirm the dimension with the user before creating — do NOT assume it.
+Marketing assets (feed posts, stories, covers, thumbnails, ad creatives) are static fixed-canvas artworks: generate them via the graphic workflow in `references/GRAPHIC.md` (`--kind graphic`), which carries the platform dimension table. MUST confirm the dimension with the user before creating — do NOT assume it.
 </marketing_assets_dimension_guidelines>
 
 ---
@@ -527,12 +527,12 @@ Every command supports `--json` for the full machine-readable payload; the defau
   - replace: use exactly one `-p`; do not use `--count`
   - `--from-version <n>`: iterate from a specific historical version instead of the current head (discover version numbers via `get-design`)
   - `--device <mobile|tablet|desktop|custom>` / `--width <pixels>` / `--height <pixels>`: OVERRIDE the viewport. Defaults to the source draft's device — omit unless deliberately changing it. `--width`/`--height` require `--device custom`.
-- create-design-draft: required `--project-id`, `--title`, and `-p` (SINGLE prompt only); optional `--device <mobile|tablet|desktop|custom>` (default: desktop), `--width <pixels>`, `--height <pixels>`, `--kind <page|poster>` (default: page), `--context-file` (one or more paths; supports `path:startLine:endLine`), `--model`, `--user-request <text>`, `--json`
+- create-design-draft: required `--project-id`, `--title`, and `-p` (SINGLE prompt only); optional `--device <mobile|tablet|desktop|custom>` (default: desktop), `--width <pixels>`, `--height <pixels>`, `--kind <page|graphic>` (default: page), `--context-file` (one or more paths; supports `path:startLine:endLine`), `--model`, `--user-request <text>`, `--json`
   - ⚠️ ONLY accepts ONE -p flag. Multiple -p flags will silently drop all but the last one.
   - Combine all design directions into a single -p string.
   - Only use this for creating purely new design from scratch.
   - --device custom requires both --width and --height (min 20px each). Providing --width/--height auto-sets --device to custom.
-  - --kind poster switches generation to the fixed-canvas poster branch (static artwork, no responsive layout) and keeps iterations in poster mode; pair it with --width/--height. See `references/POSTER.md`.
+  - --kind graphic switches generation to the fixed-canvas graphic branch (static artwork, no responsive layout) and keeps iterations in graphic mode; pair it with --width/--height. See `references/GRAPHIC.md`.
 - upload-asset: required `<file>` positional (png/jpeg/webp/gif, max 10MB) and `--project-id`; optional `--no-canvas`, `--json`. Uploads a project image asset and returns a public `url` to reference from create/iterate prompts (e.g. a poster key visual). By default the asset is also placed on the project canvas as an image node (response includes its `nodeId`); pass `--no-canvas` to skip.
 - revert-design-draft: required `--draft-id`, `--to-version <n>`; optional `--json`. Restores a prior version as the current head with NO generation; reversible (the current head is snapshotted into history first). Discover version numbers via `get-design`.
 - execute-flow-pages: required `--draft-id`, `--pages`; optional `--context`, `--context-file` (one or more paths; supports `path:startLine:endLine`), `--model`, `--json`


### PR DESCRIPTION
## What changed

Adds a **graphic / marketing-asset workflow** to the superdesign skill: the coding agent generates the key visual with its own image tool, uploads it via the new CLI `upload-asset`, then composes a fixed-canvas graphic with `create-design-draft --kind graphic`. Text always stays in the HTML layer (sharp, editable, iterable) — images carry no text.

- **New `references/GRAPHIC.md`** — the full workflow: one-round brief confirmation (verbatim copy, canvas, layout, style, asset plan), a 5-entry layout menu (type-hero / full-bleed / split / list / centered-badge) with whitespace ratios and per-layout asset plans, key-visual prompt rules (no text in images, reserve negative space, agent writes a visual description for the layout model), prompt assembly template, iterate + graphic-series rules, and a no-`--kind` fallback for older CLIs.
- **Marketing-asset dimension table moved from `SUPERDESIGN.md` into `GRAPHIC.md`** — every entry (feed posts, stories, covers, thumbnails, ad units) is a fixed-canvas artwork, so it now routes through the graphic workflow. `SUPERDESIGN.md` keeps the `<marketing_assets_dimension_guidelines>` tag as a three-line pointer (old installs referencing the tag stay valid). Also fixed the Google Display rows whose pixel sizes sat in the aspect-ratio column, and added a micro-layout rule for sub-400px ad units.
- **`SKILL.md`** — graphic/marketing-asset scenario (skips repo init), trigger keywords, command examples.
- **`COMMAND CONTRACT`** — registers `--kind <page|graphic>` and `upload-asset` so agents don't treat them as hallucinated flags.

## Dependencies / rollout order

Requires platform PR superdesigndev/superdesign-platform#1205 (server: `kind` + asset upload) deployed, then `@superdesign/cli` >= 0.7.0 published. Merge this LAST — the skill runs `@superdesign/cli@latest`, so once the CLI is on npm this works with no user action. The underlying chain (upload → `--kind graphic` → asset embedded in the generated graphic) is verified end-to-end on the platform PR (evidence links there).
