### PR TITLE
Teach extract-website; retire extract-brand-guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ Use these to discover style direction, references, and brand context. Browse the
   superdesign get-prompts --slugs "<slug>" --full             # full body of the chosen slug(s)
   ```
 
-- **Extract brand guide from a URL**
+- **Extract a site's design DNA from a URL** (style guide, tokens, content, brand, clone)
   ```bash
-  superdesign extract-brand-guide --url https://example.com
+  superdesign extract-website --url https://example.com --design-md
   ```
 
 ### B) Canvas Design Tools
@@ -200,7 +200,7 @@ Then in the iterate command:
 2. Gather inspirations (generic tools):
    - `superdesign search-prompts --tags "style"`
    - `superdesign get-prompts --slugs ...` (index first; add `--full` for the chosen slug's full body)
-   - optional: `superdesign extract-brand-guide --url ...`
+   - optional: `superdesign extract-website --url ... --design-md` (style guide → design.md; add `--brand` for assets)
 3. Ask the user to choose a direction using the session's available user-input mechanism; if none is available, ask in chat
 4. Write:
    - `.superdesign/design-system.md` (product context + UX flows + visual design, adapted to references)
@@ -264,7 +264,7 @@ superdesign get-design --draft-id <draftId> --output ./design.html
 superdesign search-prompts --query "<keyword>"
 superdesign search-prompts --tags "style"
 superdesign get-prompts --slugs "<slug1,slug2>"          # index; add --full for full bodies
-superdesign extract-brand-guide --url https://example.com
+superdesign extract-website --url https://example.com --design-md   # style guide; add --brand/--tokens/--content-structure/--clone for more
 
 # Canvas - Create project
 # Optional --template <path> seeds the first (baseline) draft from an HTML file.

--- a/skills/superdesign/SKILL.md
+++ b/skills/superdesign/SKILL.md
@@ -11,9 +11,10 @@ Superdesign helps you (1) find design inspirations/styles and (2) generate/itera
 
 1. **superdesign init** — Analyze the repo and build UI context to `.superdesign/init/`
 2. **Help me design X** (feature/page/flow)
-3. **Set design system**
+3. **Set design system** (optionally seed or refresh it from a live site via `extract-website --design-md` — you'll choose *create-from / inspired-by / update-existing*, asking first if a `design-system.md` already exists; see `references/SUPERDESIGN.md` Step 2)
 4. **Help me improve design of X**
 5. **Make a poster / marketing asset** (flyer, cover art, social feed post, story, channel cover, thumbnail, ad creative) — a static artwork, not a page. Skip repo init/analysis; read `references/GRAPHIC.md` relative to this `SKILL.md` and follow it (you generate the key visual with your own image tool, upload it, then compose the artwork on a fixed canvas; platform dimension table included).
+6. **Design from a live website / reference URL** (borrow a style, restyle, recombine, or plan a rebuild) — extract a reference site's design DNA (style guide, design tokens, content structure, brand assets, a static reference clone) with `extract-website`, then design with it. Follow "EXTRACT-WEBSITE — RECIPES & SCOPE" in `references/SUPERDESIGN.md`. Note: via the CLI a "recreate"/"clone" is a **style-informed rebuild** — faithful pixel-recreation and *editable* on-canvas clones are done in the Superdesign app (superdesign.dev), not the CLI.
 
 # Step 0 — Environment preflight (BEFORE any CLI step)
 
@@ -36,6 +37,8 @@ Two entry paths. Choose one with this cheap, deterministic check BEFORE any init
 → SKIP repo init entirely. Do NOT "analyze" an empty sandbox, and do NOT ask the user to point you at a repo they don't have. Instead, gather design context conversationally FIRST: ask what they want to build, the target audience/platform, style/brand preferences, and any reference designs or inspirations. Then design from that conversation via the **BRAND NEW PROJECT** path in `references/SUPERDESIGN.md`.
 
 **Real codebase present** (any frontend code, or an existing `.superdesign/init/`) — the repo-init path below is MANDATORY; run the full analysis before designing.
+
+**Exception — standalone extraction:** if the task is ONLY to extract a site's design DNA or set/refresh `design-system.md` from a URL (`extract-website` → `design-system.md`, no design generation), run it WITHOUT repo init — extracting an external site's style doesn't require analyzing the user's codebase. Init is still required before generating designs FOR the existing codebase's UI (reproducing/redesigning an existing page).
 
 # Init: Repo Analysis (real-codebase path)
 
@@ -87,6 +90,7 @@ Always use the full on-demand runner prefix:
 
 ```bash
 npx --yes @superdesign/cli@latest create-project --title "X"
+npx --yes @superdesign/cli@latest extract-website --url https://example.com --design-md
 npx --yes @superdesign/cli@latest create-design-draft --project-id <id> --title "Current UI" -p "Faithfully reproduce..." --context-file src/Component.tsx
 npx --yes @superdesign/cli@latest iterate-design-draft --draft-id <id> -p "dark theme" -p "minimal" --mode branch --context-file src/Component.tsx
 npx --yes @superdesign/cli@latest execute-flow-pages --draft-id <id> --pages '[{"title":"Product Details","prompt":"Product detail page with image gallery, specs and add-to-cart"},{"title":"Checkout","prompt":"Checkout page with cart summary and payment form"}]' --context-file src/Component.tsx

--- a/skills/superdesign/references/SUPERDESIGN.md
+++ b/skills/superdesign/references/SUPERDESIGN.md
@@ -228,14 +228,19 @@ Step 1 — Requirements gathering: ask the user using the session's available us
 
 Step 2 — Design system setup (MUST follow Section B):
 
-- Run: `npx --yes @superdesign/cli@latest search-prompts --tags "style"`
-- Pick the most suitable style prompt ONLY from returned results (do not do further search).
-- Fetch prompt details in TWO steps (do NOT blanket-fetch full bodies):
-  1. Index first with the default output to confirm the slug(s) and their size: `npx --yes @superdesign/cli@latest get-prompts --slugs "<slug>"`
-  2. Then fetch the full body ONLY for the chosen slug(s) right before writing design-system.md: `npx --yes @superdesign/cli@latest get-prompts --slugs "<slug>" --full`
-- Optional: `npx --yes @superdesign/cli@latest extract-brand-guide --url "<user-provided-url>"`
-- Write .superdesign/design-system.md adapted to:
-  product context + UX flows + visual direction
+- **Pick ONE primary style source — do NOT blend two competing styles:**
+  - **If the user named a reference site** ("… in the style of `<site>`", "use `<site>`'s design"): that site's extracted `design.md` is the style source (extract step below). `search-prompts` is then OPTIONAL — do NOT layer a library style prompt on top of the extracted DNA (two competing styles dilute the result).
+  - **Otherwise** (no reference site) use a library style prompt:
+    1. `npx --yes @superdesign/cli@latest search-prompts --tags "style"` — pick the most suitable ONLY from returned results (do not do further search).
+    2. Index first to confirm the slug(s) and size: `npx --yes @superdesign/cli@latest get-prompts --slugs "<slug>"`
+    3. Then fetch the full body ONLY for the chosen slug(s), right before writing design-system.md: `npx --yes @superdesign/cli@latest get-prompts --slugs "<slug>" --full`
+- Extract a reference site's style (when one was named): `npx --yes @superdesign/cli@latest extract-website --url "<user-provided-url>" --design-md` (writes `.superdesign/website/<domain>/design.md`; add `--brand` for logo/colors). Read it, then decide how it flows into `design-system.md`:
+  - **If a `design-system.md` already exists → ALWAYS ask the user first** (via the session's user-input mechanism, else in chat). NEVER silently overwrite it.
+  - If the intent is unclear, ask. If the workspace is fresh and the user clearly wants the site's look, proceed without asking. The three modes:
+    - **Create from it** — `design-system.md` = the extracted site's DNA, adopted faithfully (user wants "make it look like `<site>`").
+    - **Inspired by it** — blend the site's DNA with the product context + visual direction (cues from the site, but it stays the user's own brand). This is the default when unspecified.
+    - **Update the existing** — merge the newly-extracted DNA into the current `design-system.md`, resolving conflicts thoughtfully (adding/refreshing a reference, or iterating on an existing system).
+- Write .superdesign/design-system.md per the chosen mode (adapted to product context + UX flows + visual direction).
 
 Step 3 — Design in Superdesign:
 
@@ -543,7 +548,21 @@ Every command supports `--json` for the full machine-readable payload; the defau
 - list-design-systems: no required flags; optional `--full`, `--json`. Lists default design systems and projects available to `create-project --extend-from`.
 - search-prompts: no required flags; optional `--query <text>`, `--tags <csv>`, `--limit <n>` (default 20, max 100), `--offset <n>`, `--full`, `--json`
 - get-prompts: required `--slugs <csv>`; optional `--full` (print full prompt bodies instead of the compact index), `--json`. Index first with the default output, then re-run with `--full` for the chosen slug(s) only.
-- extract-brand-guide: required `--url <url>`; optional `--output-dir <path>` (default `.superdesign/brand_styles/<domain>`), `--json`
+- extract-website: required `--url <url>`; optional payload selectors `--design-md` (portable style guide → design.md; the default when no selector is given), `--tokens` (raw design tokens → tokens.json), `--content-structure` (content/section map → content-structure.md), `--brand` (brand metadata → brand.json), `--website-copy` (marketing copy → website-copy.md; best-effort — may come back empty), `--all` (fetch every payload; note: still pass `--clone` to actually write the clone HTML); `--brand-assets` (also download brand binaries — best logo, screenshot, page images — into `<out>/brand/`; implies `--brand`); `--clone [dir]` (save the frozen page HTML; default `<out>/clone/index.html`, pass a dir to override; assets are served from Superdesign's bucket); `--out <path>` (default `.superdesign/website/<domain>`); `--json`. An extract crawls the page server-side and can take ~60–120s. Supersedes the older `extract-brand-guide`.
 
 **Supported --model values**: gemini-3-flash, gemini-3.1-pro, claude-haiku-4-5, claude-sonnet-5, claude-opus-4-8, gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, gpt-5.5, gpt-5.4, gpt-5.4-mini, gpt-5-mini, grok-4.5, kimi-k2.6, deepseek-v4-pro, deepseek-v4-flash, glm-5.2
 If --model is omitted, the backend uses the default model. Only pass --model when the user explicitly requests a specific model.
+
+---
+
+## EXTRACT-WEBSITE — RECIPES & SCOPE
+
+`extract-website` pulls a live site's design DNA into `.superdesign/website/<domain>/` as files. It hands you inputs — it does NOT reproduce, merge, or place designs. Feed the outputs into the normal Superdesign flow:
+
+- **Borrow a site's style** (e.g. "design … in the style of linear.app"): `extract-website --url <site> --design-md` → read `design.md` (a portable style guide) and fold it into `.superdesign/design-system.md` (Step 2 — choose **create-from / inspired-by / update-existing**; if a `design-system.md` already exists, ASK before overwriting), then design as usual. Add `--brand` for logo/colors/fonts (`brand.json`), and `upload-asset` the logo into the project if you want it used.
+- **Restyle / recombination** (e.g. "redesign framer.com in apple.com's style", "clickup's page structure with raycast's aesthetic"): extract `--content-structure` from the CONTENT site (read `content-structure.md` and use it to shape your `-p` draft prompt or the `execute-flow-pages` page list) and `--design-md` from the STYLE site (adapt into design-system.md). The result is a style-informed rebuild, not a pixel copy.
+- **Merge multiple styles** (e.g. "merge stripe.com and vercel.com"): extract `--design-md` from each and blend them into one design-system.md, then design.
+- **Design tokens**: `--tokens` → `tokens.json`, for wiring into your own Tailwind/CSS if you're building in a codebase.
+- **Reference clone**: `--clone` → `clone/index.html` (static; assets served from Superdesign's bucket) — a visual reference to look at while you build. It is NOT editable and NOT a generation input.
+
+**Scope boundary (do not overpromise):** faithful pixel-recreation of a site and *editable* on-canvas clones — freezing the real page as a draft you can edit, plus governing-style pinning and deliberate multi-site merges — run in the **Superdesign canvas app** (superdesign.dev), which has the full extraction-and-placement pipeline. Through the CLI, a user's "recreate this site" or "clone this page" is a **style-informed rebuild**, not a copy. Deliver that honestly, and point users to the app when they need a true clone.


### PR DESCRIPTION
## What changed

Retire the narrow `extract-brand-guide` and teach the richer **`extract-website`** (shipped in `@superdesign/cli@0.8.0`) — a strict superset that extracts a site's style guide, design tokens, content structure, brand assets, and a static clone.

### `SKILL.md` (router)
- New scenario **"Design from a live website / reference URL"** (borrow / restyle / recombine / rebuild), with the honest boundary: a CLI "recreate"/"clone" is a **style-informed rebuild** — faithful pixel-recreation and *editable* on-canvas clones live in the app, not the CLI.
- One command example; a "Set design system" cross-link; and an exemption so a **standalone extraction** ("set design system from a URL") skips the mandatory repo-init gate.

### `references/SUPERDESIGN.md` (workflow + contract)
- `extract-website` command contract (replaces `extract-brand-guide`).
- **Step 2 rework:** pick ONE primary style source (a named site's extracted `design.md` OR a library style prompt — not both), plus a **3-way design-system decision** (create-from / inspired-by / update-existing) that **ALWAYS asks before overwriting** an existing `design-system.md`.
- New **"EXTRACT-WEBSITE — RECIPES & SCOPE"** section: use-case recipes routed through the real flow (`design-system.md`, `--context-file`, `upload-asset`), with an explicit CLI-vs-app scope boundary.

### `README.md`
- The 3 human-facing examples updated to `extract-website`.

## Validation
- Independent review of the core edits (verdict: sound; both nice-to-haves applied).
- **6-case agent dry-run** — style-borrow, recombination, merge, editable-clone boundary, brand-assets, and the overwrite guardrail — **all passed** (correct routing, flag choice, content-vs-style role assignment, decision branch, honest boundaries).
- The **extract → project → draft** chain confirmed **live on prod** (real draft rendered, 3.5 credits).

## Note
The two Step-2 refinements (one-primary-style-source; init exemption) were added *after* the dry-run that surfaced them — reviewer-checked doc clarifications, but not separately dry-run-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)