### PR TITLE
Teach Codex embedded canvas (canvas-link) and network-timeout troubleshooting

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "superdesign",
-  "version": "0.2.0",
-  "description": "Superdesign adds a product-design skill to Codex.",
+  "version": "0.3.0",
+  "description": "Superdesign adds a product-design skill to ChatGPT.",
   "author": {
     "name": "Superdesign dev, Inc.",
     "email": "support@superdesign.dev",
@@ -20,7 +20,7 @@
   "interface": {
     "displayName": "Superdesign",
     "shortDescription": "Create and iterate UI designs",
-    "longDescription": "Superdesign adds a product-design skill to Codex. Ask for a screen, a landing page, or a whole flow, and Codex drives the Superdesign CLI to generate polished UI design drafts you can open on an infinite canvas in your browser.\n\nExplore directions in parallel: give a few prompts like \"dark theme\", \"minimal\", \"bold\" and compare side-by-side variations. Iterate on the one you like, branch alternatives, and revert to any earlier version.\n\nTo keep results on-brand, it can extract brand guidelines from a website, extend existing design systems, search a community prompt library for inspiration, and reuse components across drafts.",
+    "longDescription": "Superdesign adds a product-design skill to ChatGPT. Ask for a screen, a landing page, or a whole flow, and ChatGPT drives the Superdesign CLI to generate polished UI design drafts you can open on an infinite canvas in your browser.\n\nExplore directions in parallel: give a few prompts like \"dark theme\", \"minimal\", \"bold\" and compare side-by-side variations. Iterate on the one you like, branch alternatives, and revert to any earlier version.\n\nTo keep results on-brand, it can extract brand guidelines from a website, extend existing design systems, search a community prompt library for inspiration, and reuse components across drafts.",
     "developerName": "Superdesign",
     "category": "Developer Tools",
     "capabilities": [
@@ -34,7 +34,7 @@
     "defaultPrompt": [
       "Help me design a landing page for this project.",
       "Explore three visual directions for this product.",
-      "Turn this rough screen into a polished end-to-end flow that feels native to our brand."
+      "Create a launch graphic for this product to share on X and LinkedIn."
     ],
     "brandColor": "#000000",
     "composerIcon": "./assets/superdesign-icon.png",

--- a/skills/superdesign/SKILL.md
+++ b/skills/superdesign/SKILL.md
@@ -124,10 +124,14 @@ After creating a project or design draft, and at natural review moments (after `
 
 ## Codex embedded canvas (Browser side panel)
 
-When you are running **inside Codex with the built-in Browser side panel available**, drop the finished design straight into that panel so the user can view and hand-tweak it immediately — no login step for them. After completing design work (a draft/flow the user is ready to look at):
+When you are running **inside Codex with the built-in Browser side panel available**, drop the finished design straight into that panel so the user can view and hand-tweak it immediately — no login step for them. After completing design work (a draft/flow the user is ready to look at), and only when Codex's in-app Browser is available:
 
-1. Run `npx --yes @superdesign/cli@latest canvas-link <projectId>`. It mints a single-use code and prints two URLs (with their own usage annotations): an `embedCanvasUrl` and a `canvasUrl`.
-2. Open the returned **`embedCanvasUrl`** in the Browser panel. It auto-signs-in to a restricted embedded canvas — view + manual edit only, no chat/agent, no navigation — so the user can see and manually edit the design right away, no login needed.
+1. **Mint the URL:** run `npx --yes @superdesign/cli@latest canvas-link <projectId>`. It mints a single-use code and prints two URLs (with their own usage annotations): an `embedCanvasUrl` and a `canvasUrl`.
+2. **Open `embedCanvasUrl` specifically in the Codex in-app Browser.** It auto-signs-in to a restricted embedded canvas — view + manual edit only, no chat/agent, no navigation — so the user can see and manually edit the design right away, no login needed.
+   - Make the in-app Browser visible to the user.
+   - Keep the canvas tab open as a user-facing deliverable.
+   - Verify that the selected tab's URL is the embedded canvas URL.
+3. **Do NOT use external Chrome, system `open`, Playwright launched from the shell, or Chrome DevTools automation for this step.** Those surfaces may navigate successfully without opening Codex's visible Browser panel — the navigation "succeeds" but the user sees nothing.
 
 `create-project` always auto-opens the user's system browser by default, in every context. When running inside Codex (or any agent-embedded surface), pass `--no-open` to `create-project` so that system browser does not pop; then show the user the canvas through this embedded flow instead (`canvas-link`, then open `embedCanvasUrl` in the Browser panel) — THE way to surface the canvas in Codex.
 

--- a/skills/superdesign/SKILL.md
+++ b/skills/superdesign/SKILL.md
@@ -150,8 +150,6 @@ Rules:
 - **The embedded canvas has no chat/agent.** All generation and iteration keep happening from THIS coding-agent session (`create-design-draft` / `iterate-design-draft` / `execute-flow-pages` as usual); the panel is a view-and-manual-edit surface only.
 - **Never surface `embedCanvasUrl` to a human or open it in a normal external browser.** It is single-use and short-lived — an agent-surface-only link. Any link you give a person, or open outside the Browser panel, MUST be the clean, durable `canvasUrl` (it requires login, like every other canvas URL you surface).
 - **The embedded session expires after 1 hour.** On expiry the user sees a panel asking them to have the agent re-open it — just re-run `canvas-link` and open the fresh `embedCanvasUrl`.
-- **Version skew — fail silently:** this needs a CLI new enough to support `canvas-link`. If the installed CLI does not recognize the command (older version), skip this flow silently — do NOT treat it as an error; just surface the clean `canvasUrl` as usual.
-- **Version skew — `--no-open`:** the `--no-open` flag exists from CLI `0.9.0-beta.2`. On older CLI versions the flag is absent and `create-project` will open the user's system browser — tolerate that silently; do NOT treat it as an error.
 
 ### After each generation: self-review, then offer to go further
 

--- a/skills/superdesign/SKILL.md
+++ b/skills/superdesign/SKILL.md
@@ -45,24 +45,28 @@ Two entry paths. Choose one with this cheap, deterministic check BEFORE any init
 When the user makes a simple, open-ended design request — one sentence, no strong constraints — do NOT generate immediately. First propose THREE genuinely distinct creative directions and confirm the choice with the user:
 
 - Each direction is 1-2 lines: a named style/concept plus what sets it apart (art direction, mood, composition, key visual idea). The three MUST differ substantially — not three shades of one idea.
-- Recommend trying all three — generated as parallel variants for side-by-side comparison on the canvas — while noting that picking just one (or two) is a fine choice if they prefer. Only generate after the user responds.
+- Recommend trying all three — generated as parallel variants for side-by-side comparison on the canvas — while noting that picking just one (or two) is a fine choice if they prefer. Only generate after the user responds. **When the user accepts the "try all three" recommendation, that counts as explicitly asking for 3 variants** (this is the sanctioned way to exceed the default 2 — see the VARIANT COUNT rule in `references/SUPERDESIGN.md`); generate the three as parallel variants.
 - When the request already carries detailed constraints or an explicit style, SKIP the divergence and follow the user's spec directly — this default is only for underspecified asks.
 
 This applies across every scenario (pages, flows, posters/graphics), on both entry paths. It pairs with the after-generation follow-up: diverge before the first generation, offer to go further after it.
 
+**On the graphic path the divergence is NOT a separate round.** The graphic workflow confirms its brief in ONE round (`references/GRAPHIC.md` Step 1), so fold the three directions INTO that single brief-confirmation round: present three distinct directions — each carrying its own layout/style/asset-plan — while the shared copy and canvas are confirmed once. Do not add a second confirmation round.
+
 # Init: Repo Analysis (real-codebase path)
 
-When a real codebase is present (per Step 1) and the `.superdesign/init/` directory doesn't exist or is empty, you MUST automatically:
+When a real codebase is present (per Step 1) and init is NOT complete, you MUST automatically:
 
 1. Create the `.superdesign/init/` directory
 2. Read `references/INIT.md` relative to this selected `SKILL.md`
 3. Follow its instructions to analyze the repo and write context files
 
+**Init-complete test (one decidable rule, used everywhere):** init is complete only if all six named files below exist AND are non-empty. A directory that is missing any of them, or holds an empty one (e.g. an interrupted init), is NOT complete — rerun the full init, which regenerates all six; overwriting existing files is expected and fine.
+
 Do NOT ask the user to do this manually — just do it.
 
 # Mandatory Init Files
 
-If `.superdesign/init/` exists, you MUST read ALL files in this directory FIRST before any design task:
+If init is complete (all six files present and non-empty), you MUST read ALL of them FIRST before any design task:
 
 - `components.md` — shared UI primitives with full source code
 - `layouts.md` — shared layout components (nav, sidebar, header, footer)
@@ -71,7 +75,7 @@ If `.superdesign/init/` exists, you MUST read ALL files in this directory FIRST 
 - `pages.md` — page component dependency trees (which files each page needs)
 - `extractable-components.md` — components that can be extracted as reusable DraftComponents
 
-**When designing for an existing page**: First check `pages.md` for the page's complete dependency tree. Every file in that tree MUST be passed as `--context-file`. Then also add globals.css, tailwind.config, and design-system.md.
+**When designing for an existing page**: First check `pages.md` for the page's dependency tree — the candidate set of `--context-file` files. Pass them under the PAYLOAD BUDGET rules in `references/SUPERDESIGN.md` (line-range ~900+ line files to their render/token sections; drop files with no visual bearing) so the payload does not 400. Then also add the globals.css tokens, tailwind.config, and design-system.md.
 
 # Superdesign CLI (MUST use before any command)
 
@@ -92,11 +96,18 @@ Follow these steps in order — do NOT skip any step:
    Wait for login to complete successfully before proceeding.
 3. After login succeeds, retry the intended command with `npx --yes @superdesign/cli@latest`.
 
-> **Never assume the user is already logged in.** Always verify login first.
+> **Never assume the user is already logged in.** There is no separate "verify login" command — your `--version` check plus reacting to an auth/login error on the first real command IS the verification. Do not try to run a whoami/status check; just run the intended command and handle an auth error per the failure block below.
+
+## When a command fails
+
+- **Auth/login error** (the CLI ran but rejected the session): run `login` (above), then retry the intended command ONCE. If login itself fails (headless/no-browser auth, expired flow, user declines), tell the user plainly and STOP — do not keep retrying or improvise.
+- **`search-prompts` returns zero results**: proceed WITHOUT a library style prompt (note that to the user) — do not keep searching; the flow works fine without one.
+- **`extract-website` fails or times out** (it can take ~60–120s): retry ONCE. If it still fails, offer to continue WITHOUT the extraction (design from the conversation / existing design system) rather than blocking.
+- **General rule:** retry a failed command at most once, then report the failure to the user and stop — never silently loop or fall back to inventing output.
 
 ## If Superdesign requests repeatedly time out
 
-If network requests to Superdesign (CLI/API calls) repeatedly time out, first CHECK WITH THE USER whether they are currently running in **Codex Web (browser) mode**. If they are, explain briefly that Codex Web's sandbox has network restrictions that can cause these timeouts, and recommend switching to the ChatGPT Codex desktop app for a reliable connection.
+If network requests to Superdesign (CLI/API calls) repeatedly time out: if you can determine your own environment, only raise the Codex Web possibility when you ARE actually running in Codex Web (browser) mode — in that case explain briefly that Codex Web's sandbox has network restrictions that can cause these timeouts, and recommend switching to the ChatGPT Codex desktop app for a reliable connection. Otherwise (you are not in Codex Web, or cannot tell), retry once and report the failure to the user — do NOT burn a user round asking about a surface you are not on.
 
 ## Command examples
 
@@ -134,16 +145,18 @@ After creating a project or design draft, and at natural review moments (after `
 
 ## Codex embedded canvas (Browser side panel)
 
-When you are running **inside Codex with the built-in Browser side panel available**, drop the finished design straight into that panel so the user can view and hand-tweak it immediately — no login step for them. After completing design work (a draft/flow the user is ready to look at), and only when Codex's in-app Browser is available:
+When you are running **inside Codex with the built-in Browser side panel available**, drop the finished design straight into that panel so the user can view and hand-tweak it immediately — no login step for them. After completing design work (a draft/flow the user is ready to look at), use this flow only when the capability test below passes.
 
-1. **Mint the URL:** run `npx --yes @superdesign/cli@latest canvas-link <projectId>`. It mints a code and prints two URLs (with their own usage annotations): an `embedCanvasUrl` and a `canvasUrl`.
+**Browser capability test (decidable — all must hold):** use the in-app Browser embedded flow ONLY if you have a host-provided in-app-browser tool that (a) explicitly controls the user-visible Codex Browser side panel (not an external/headless browser), AND (b) can navigate to a URL, AND (c) can inspect the selected tab's URL and its rendered page (screenshot or page inspection). If any of these is missing or fails, do NOT mint or open the embed link — fall back: surface the clean `canvasUrl` (from `canvas-link`, or the `canvas:` link in any command's output) to the user as a clickable link and continue with the normal non-embedded review flow. Also fall back this way if `canvas-link` itself is unavailable in the CLI — surface the clean `canvas:` URL from the command output instead.
+
+1. **Mint the URL:** run `npx --yes @superdesign/cli@latest canvas-link <projectId>`. It mints a code and prints two URLs (with their own usage annotations): an `embedCanvasUrl` and a `canvasUrl`. (If `canvas-link` is not available, fall back to the clean `canvas:` URL as above.)
 2. **Open `embedCanvasUrl` specifically in the Codex in-app Browser.** It auto-signs-in to a restricted embedded canvas — view + manual edit only, no chat/agent, no navigation — so the user can see and manually edit the design right away, no login needed.
    - Make the in-app Browser visible to the user.
    - Keep the canvas tab open as a user-facing deliverable.
    - Verify that the selected tab's URL is the embedded canvas URL.
 3. **Do NOT use external Chrome, system `open`, Playwright launched from the shell, or Chrome DevTools automation for this step.** Those surfaces may navigate successfully without opening Codex's visible Browser panel — the navigation "succeeds" but the user sees nothing.
 
-`create-project` always auto-opens the user's system browser by default, in every context. When running inside Codex (or any agent-embedded surface), pass `--no-open` to `create-project` so that system browser does not pop; then show the user the canvas through this embedded flow instead (`canvas-link`, then open `embedCanvasUrl` in the Browser panel) — THE way to surface the canvas in Codex.
+`create-project` always auto-opens the user's system browser by default (the canvas URL is printed either way). **Decidable rule: if you — the agent — are running the command rather than a human typing it at their own shell, pass `--no-open`** and surface the printed URL yourself. That covers Codex, Claude Code in a terminal, CI, and every agent-driven surface; it prevents an uncontrolled system-browser pop mid-session. In Codex specifically, after `--no-open` you then show the canvas through this embedded flow (`canvas-link`, then open `embedCanvasUrl` in the Browser panel) — THE way to surface the canvas in Codex.
 
 Rules:
 
@@ -151,16 +164,22 @@ Rules:
 - **Never surface `embedCanvasUrl` to a human or open it in a normal external browser.** It auto-signs-in whoever opens it, so it is an agent-surface-only link. Any link you give a person, or open outside the Browser panel, MUST be the clean, durable `canvasUrl` (it requires login, like every other canvas URL you surface).
 - **The `embedCanvasUrl` stays valid for about an hour** and can be opened again from this conversation during that window — reopening it, or opening it in another tab, works fine. Once it expires, the embedded session shows a panel asking the user to have the agent re-open it; just re-run `canvas-link` and open the fresh `embedCanvasUrl`.
 
-### After each generation: self-review, then offer to go further
+# After generating: self-review, then offer to go further
 
-Whenever the embedded canvas is your surface, treat every generation round (`create-design-draft` / `iterate-design-draft` / `execute-flow-pages`) as unfinished until you have looked at the rendered result yourself.
+This applies on EVERY surface, not only the Codex embedded canvas.
 
-1. **Look at it.** Open or refresh the embedded canvas in the in-app Browser (per the tool-routing rules above) and actually inspect the rendered page, using the Browser panel's page inspection/screenshot capability. Judge it as a designer would: layout breakage, overflow or clipping, contrast and readability, typography scale, spacing rhythm, leftover placeholder or filler content, and image fit.
-2. **Fix once if needed.** If you spot concrete issues, run EXACTLY ONE optimization iteration (`iterate-design-draft`) that addresses them, then re-check the result in the Browser. One round only: never keep looping on your own. Extra iterations cost the user credits, so any further pass waits for the user to ask.
-3. **Present.** Show the result to the user with the canvas visible in the Browser panel.
+**Visual self-review (when you can safely inspect).** If you have a safe visual-inspection capability for the rendered result — the Codex Browser panel's page inspection/screenshot, or any sandboxed screenshot/preview tool your host provides — treat every design generation round (`create-design-draft` / `iterate-design-draft` / `execute-flow-pages`) as unfinished until you have looked at it yourself:
 
-Then always close with a short, warm follow-up that offers to go further. Ask one question with 2 to 3 concrete options tailored to what you just made, not a generic list. For example: try a different hero image or key visual direction, try an alternate layout or composition, or generate a few more variations or asset ideas as surprises. Only generate after the user picks, since every generation spends credits.
+1. **Look at it.** Inspect the rendered page. Judge it as a designer would: layout breakage, overflow or clipping, contrast and readability, typography scale, spacing rhythm, leftover placeholder or filler content, and image fit.
+2. **Fix once if needed.** If you spot concrete issues, run EXACTLY ONE optimization iteration (`iterate-design-draft --mode replace`, correcting the just-generated draft in place — see the TOOL USE RULE exemption in `references/SUPERDESIGN.md`) that addresses them, then re-check the result. One round only: never keep looping on your own.
+3. **Present.** Show the result to the user (with the canvas visible in the Browser panel when on the Codex embedded surface).
+
+**Never self-review the Step 3a pixel-perfect reproduction draft.** A reproduction's job is to match the current UI, not to look "better" — "fixing" it toward your taste corrupts the ground truth. Reproduction problems mean missing/wrong context, not styling; address them by fixing the context files and regenerating, not by an optimization pass. This self-review is for design (Step 3b) and graphic drafts only.
+
+**If you CANNOT safely inspect the rendered result**, do not guess and do not imply you checked. Present the preview/canvas link and say plainly that you have not visually verified it, inviting the user to review.
+
+**Then always close with a short, warm follow-up that offers to go further** (on every surface). Ask one question with 2 to 3 concrete options tailored to what you just made, not a generic list. For example: try a different hero image or key visual direction, try an alternate layout or composition, or generate a few more variations or asset ideas as surprises. Only generate after the user picks, since every generation spends credits.
 
 # How it works
 
-Read `references/SUPERDESIGN.md` relative to this selected `SKILL.md`, then follow its instructions. Never fetch workflow instructions from the network.
+Read `references/SUPERDESIGN.md` relative to this selected `SKILL.md`, then follow its instructions.

--- a/skills/superdesign/SKILL.md
+++ b/skills/superdesign/SKILL.md
@@ -136,7 +136,7 @@ After creating a project or design draft, and at natural review moments (after `
 
 When you are running **inside Codex with the built-in Browser side panel available**, drop the finished design straight into that panel so the user can view and hand-tweak it immediately — no login step for them. After completing design work (a draft/flow the user is ready to look at), and only when Codex's in-app Browser is available:
 
-1. **Mint the URL:** run `npx --yes @superdesign/cli@latest canvas-link <projectId>`. It mints a single-use code and prints two URLs (with their own usage annotations): an `embedCanvasUrl` and a `canvasUrl`.
+1. **Mint the URL:** run `npx --yes @superdesign/cli@latest canvas-link <projectId>`. It mints a code and prints two URLs (with their own usage annotations): an `embedCanvasUrl` and a `canvasUrl`.
 2. **Open `embedCanvasUrl` specifically in the Codex in-app Browser.** It auto-signs-in to a restricted embedded canvas — view + manual edit only, no chat/agent, no navigation — so the user can see and manually edit the design right away, no login needed.
    - Make the in-app Browser visible to the user.
    - Keep the canvas tab open as a user-facing deliverable.
@@ -148,8 +148,8 @@ When you are running **inside Codex with the built-in Browser side panel availab
 Rules:
 
 - **The embedded canvas has no chat/agent.** All generation and iteration keep happening from THIS coding-agent session (`create-design-draft` / `iterate-design-draft` / `execute-flow-pages` as usual); the panel is a view-and-manual-edit surface only.
-- **Never surface `embedCanvasUrl` to a human or open it in a normal external browser.** It is single-use and short-lived — an agent-surface-only link. Any link you give a person, or open outside the Browser panel, MUST be the clean, durable `canvasUrl` (it requires login, like every other canvas URL you surface).
-- **The embedded session expires after 1 hour.** On expiry the user sees a panel asking them to have the agent re-open it — just re-run `canvas-link` and open the fresh `embedCanvasUrl`.
+- **Never surface `embedCanvasUrl` to a human or open it in a normal external browser.** It auto-signs-in whoever opens it, so it is an agent-surface-only link. Any link you give a person, or open outside the Browser panel, MUST be the clean, durable `canvasUrl` (it requires login, like every other canvas URL you surface).
+- **The `embedCanvasUrl` stays valid for about an hour** and can be opened again from this conversation during that window — reopening it, or opening it in another tab, works fine. Once it expires, the embedded session shows a panel asking the user to have the agent re-open it; just re-run `canvas-link` and open the fresh `embedCanvasUrl`.
 
 ### After each generation: self-review, then offer to go further
 

--- a/skills/superdesign/SKILL.md
+++ b/skills/superdesign/SKILL.md
@@ -143,6 +143,16 @@ Rules:
 - **Version skew — fail silently:** this needs a CLI new enough to support `canvas-link`. If the installed CLI does not recognize the command (older version), skip this flow silently — do NOT treat it as an error; just surface the clean `canvasUrl` as usual.
 - **Version skew — `--no-open`:** the `--no-open` flag exists from CLI `0.9.0-beta.2`. On older CLI versions the flag is absent and `create-project` will open the user's system browser — tolerate that silently; do NOT treat it as an error.
 
+### After each generation: self-review, then offer to go further
+
+Whenever the embedded canvas is your surface, treat every generation round (`create-design-draft` / `iterate-design-draft` / `execute-flow-pages`) as unfinished until you have looked at the rendered result yourself.
+
+1. **Look at it.** Open or refresh the embedded canvas in the in-app Browser (per the tool-routing rules above) and actually inspect the rendered page, using the Browser panel's page inspection/screenshot capability. Judge it as a designer would: layout breakage, overflow or clipping, contrast and readability, typography scale, spacing rhythm, leftover placeholder or filler content, and image fit.
+2. **Fix once if needed.** If you spot concrete issues, run EXACTLY ONE optimization iteration (`iterate-design-draft`) that addresses them, then re-check the result in the Browser. One round only: never keep looping on your own. Extra iterations cost the user credits, so any further pass waits for the user to ask.
+3. **Present.** Show the result to the user with the canvas visible in the Browser panel.
+
+Then always close with a short, warm follow-up that offers to go further. Ask one question with 2 to 3 concrete options tailored to what you just made, not a generic list. For example: try a different hero image or key visual direction, try an alternate layout or composition, or generate a few more variations or asset ideas as surprises. Only generate after the user picks, since every generation spends credits.
+
 # How it works
 
 Read `references/SUPERDESIGN.md` relative to this selected `SKILL.md`, then follow its instructions. Never fetch workflow instructions from the network.

--- a/skills/superdesign/SKILL.md
+++ b/skills/superdesign/SKILL.md
@@ -40,6 +40,16 @@ Two entry paths. Choose one with this cheap, deterministic check BEFORE any init
 
 **Exception — standalone extraction:** if the task is ONLY to extract a site's design DNA or set/refresh `design-system.md` from a URL (`extract-website` → `design-system.md`, no design generation), run it WITHOUT repo init — extracting an external site's style doesn't require analyzing the user's codebase. Init is still required before generating designs FOR the existing codebase's UI (reproducing/redesigning an existing page).
 
+# Default: diverge first on simple, open-ended requests
+
+When the user makes a simple, open-ended design request — one sentence, no strong constraints (the classic case: "Make me a tourism poster for Kanazawa, Japan") — do NOT generate immediately. First propose THREE genuinely distinct creative directions and confirm the choice with the user:
+
+- Each direction is 1-2 lines: a named style/concept plus what sets it apart (art direction, mood, composition, key visual idea). The three MUST differ substantially — not three shades of one idea. For the Kanazawa poster, for example: a Japanese-minimal seasonal-garden direction; a retro travel-poster gold-leaf craft direction; a bold photographic street-and-food direction.
+- Ask the user to pick one (or say "surprise me" / "all three"). Only generate after they choose. If they pick "all three", generate them as parallel variants for side-by-side comparison on the canvas.
+- When the request already carries detailed constraints or an explicit style, SKIP the divergence and follow the user's spec directly — this default is only for underspecified asks.
+
+This applies across every scenario (pages, flows, posters/graphics), on both entry paths. It pairs with the after-generation follow-up: diverge before the first generation, offer to go further after it.
+
 # Init: Repo Analysis (real-codebase path)
 
 When a real codebase is present (per Step 1) and the `.superdesign/init/` directory doesn't exist or is empty, you MUST automatically:

--- a/skills/superdesign/SKILL.md
+++ b/skills/superdesign/SKILL.md
@@ -18,6 +18,8 @@ Superdesign helps you (1) find design inspirations/styles and (2) generate/itera
 
 # Step 0 — Environment preflight (BEFORE any CLI step)
 
+If you are in the ChatGPT/Codex web app (or network requests to Superdesign repeatedly time out), stop there and send the user to the desktop app.
+
 Superdesign runs entirely through its CLI, so you must be able to execute shell commands. Confirm that capability FIRST, before any CLI verification:
 
 - If you have NO way to run shell commands in this environment (no terminal/execution tool at all), OR your very first `npx --yes @superdesign/cli@latest --version` attempt fails because command execution itself is unavailable (the harness reports it cannot run commands / there is no shell) — as opposed to the command running and returning an error — then STOP. Do NOT keep retrying or improvise workarounds.
@@ -104,10 +106,6 @@ Follow these steps in order — do NOT skip any step:
 - **`search-prompts` returns zero results**: proceed WITHOUT a library style prompt (note that to the user) — do not keep searching; the flow works fine without one.
 - **`extract-website` fails or times out** (it can take ~60–120s): retry ONCE. If it still fails, offer to continue WITHOUT the extraction (design from the conversation / existing design system) rather than blocking.
 - **General rule:** retry a failed command at most once, then report the failure to the user and stop — never silently loop or fall back to inventing output.
-
-## If Superdesign requests repeatedly time out
-
-If network requests to Superdesign (CLI/API calls) repeatedly time out: if you can determine your own environment, only raise the Codex Web possibility when you ARE actually running in Codex Web (browser) mode — in that case explain briefly that Codex Web's sandbox has network restrictions that can cause these timeouts, and recommend switching to the ChatGPT Codex desktop app for a reliable connection. Otherwise (you are not in Codex Web, or cannot tell), retry once and report the failure to the user — do NOT burn a user round asking about a surface you are not on.
 
 ## Command examples
 

--- a/skills/superdesign/SKILL.md
+++ b/skills/superdesign/SKILL.md
@@ -129,12 +129,15 @@ When you are running **inside Codex with the built-in Browser side panel availab
 1. Run `npx --yes @superdesign/cli@latest canvas-link <projectId>`. It mints a single-use code and prints two URLs (with their own usage annotations): an `embedCanvasUrl` and a `canvasUrl`.
 2. Open the returned **`embedCanvasUrl`** in the Browser panel. It auto-signs-in to a restricted embedded canvas — view + manual edit only, no chat/agent, no navigation — so the user can see and manually edit the design right away, no login needed.
 
+From CLI `0.9.0-beta.2`, `create-project` detects agent contexts (including Codex) and no longer auto-opens the user's system browser; it still prints the canvas URL. In Codex this embedded-canvas flow (`canvas-link`, then open `embedCanvasUrl` in the Browser panel) is THE way to show the user the canvas.
+
 Rules:
 
 - **The embedded canvas has no chat/agent.** All generation and iteration keep happening from THIS coding-agent session (`create-design-draft` / `iterate-design-draft` / `execute-flow-pages` as usual); the panel is a view-and-manual-edit surface only.
 - **Never surface `embedCanvasUrl` to a human or open it in a normal external browser.** It is single-use and short-lived — an agent-surface-only link. Any link you give a person, or open outside the Browser panel, MUST be the clean, durable `canvasUrl` (it requires login, like every other canvas URL you surface).
 - **The embedded session expires after 1 hour.** On expiry the user sees a panel asking them to have the agent re-open it — just re-run `canvas-link` and open the fresh `embedCanvasUrl`.
 - **Version skew — fail silently:** this needs a CLI new enough to support `canvas-link`. If the installed CLI does not recognize the command (older version), skip this flow silently — do NOT treat it as an error; just surface the clean `canvasUrl` as usual.
+- **Version skew — system browser may still pop:** on CLI versions older than `0.9.0-beta.2`, `create-project` may still open the user's system browser. If the installed CLI supports it, pass `--no-open` to `create-project` to suppress that explicitly.
 
 # How it works
 

--- a/skills/superdesign/SKILL.md
+++ b/skills/superdesign/SKILL.md
@@ -42,9 +42,9 @@ Two entry paths. Choose one with this cheap, deterministic check BEFORE any init
 
 # Default: diverge first on simple, open-ended requests
 
-When the user makes a simple, open-ended design request — one sentence, no strong constraints (the classic case: "Make me a tourism poster for Kanazawa, Japan") — do NOT generate immediately. First propose THREE genuinely distinct creative directions and confirm the choice with the user:
+When the user makes a simple, open-ended design request — one sentence, no strong constraints — do NOT generate immediately. First propose THREE genuinely distinct creative directions and confirm the choice with the user:
 
-- Each direction is 1-2 lines: a named style/concept plus what sets it apart (art direction, mood, composition, key visual idea). The three MUST differ substantially — not three shades of one idea. For the Kanazawa poster, for example: a Japanese-minimal seasonal-garden direction; a retro travel-poster gold-leaf craft direction; a bold photographic street-and-food direction.
+- Each direction is 1-2 lines: a named style/concept plus what sets it apart (art direction, mood, composition, key visual idea). The three MUST differ substantially — not three shades of one idea.
 - Ask the user to pick one (or say "surprise me" / "all three"). Only generate after they choose. If they pick "all three", generate them as parallel variants for side-by-side comparison on the canvas.
 - When the request already carries detailed constraints or an explicit style, SKIP the divergence and follow the user's spec directly — this default is only for underspecified asks.
 

--- a/skills/superdesign/SKILL.md
+++ b/skills/superdesign/SKILL.md
@@ -45,7 +45,7 @@ Two entry paths. Choose one with this cheap, deterministic check BEFORE any init
 When the user makes a simple, open-ended design request — one sentence, no strong constraints — do NOT generate immediately. First propose THREE genuinely distinct creative directions and confirm the choice with the user:
 
 - Each direction is 1-2 lines: a named style/concept plus what sets it apart (art direction, mood, composition, key visual idea). The three MUST differ substantially — not three shades of one idea.
-- Ask the user to pick one (or say "surprise me" / "all three"). Only generate after they choose. If they pick "all three", generate them as parallel variants for side-by-side comparison on the canvas.
+- Recommend trying all three — generated as parallel variants for side-by-side comparison on the canvas — while noting that picking just one (or two) is a fine choice if they prefer. Only generate after the user responds.
 - When the request already carries detailed constraints or an explicit style, SKIP the divergence and follow the user's spec directly — this default is only for underspecified asks.
 
 This applies across every scenario (pages, flows, posters/graphics), on both entry paths. It pairs with the after-generation follow-up: diverge before the first generation, offer to go further after it.

--- a/skills/superdesign/SKILL.md
+++ b/skills/superdesign/SKILL.md
@@ -129,7 +129,7 @@ When you are running **inside Codex with the built-in Browser side panel availab
 1. Run `npx --yes @superdesign/cli@latest canvas-link <projectId>`. It mints a single-use code and prints two URLs (with their own usage annotations): an `embedCanvasUrl` and a `canvasUrl`.
 2. Open the returned **`embedCanvasUrl`** in the Browser panel. It auto-signs-in to a restricted embedded canvas — view + manual edit only, no chat/agent, no navigation — so the user can see and manually edit the design right away, no login needed.
 
-From CLI `0.9.0-beta.2`, `create-project` detects agent contexts (including Codex) and no longer auto-opens the user's system browser; it still prints the canvas URL. In Codex this embedded-canvas flow (`canvas-link`, then open `embedCanvasUrl` in the Browser panel) is THE way to show the user the canvas.
+`create-project` always auto-opens the user's system browser by default, in every context. When running inside Codex (or any agent-embedded surface), pass `--no-open` to `create-project` so that system browser does not pop; then show the user the canvas through this embedded flow instead (`canvas-link`, then open `embedCanvasUrl` in the Browser panel) — THE way to surface the canvas in Codex.
 
 Rules:
 
@@ -137,7 +137,7 @@ Rules:
 - **Never surface `embedCanvasUrl` to a human or open it in a normal external browser.** It is single-use and short-lived — an agent-surface-only link. Any link you give a person, or open outside the Browser panel, MUST be the clean, durable `canvasUrl` (it requires login, like every other canvas URL you surface).
 - **The embedded session expires after 1 hour.** On expiry the user sees a panel asking them to have the agent re-open it — just re-run `canvas-link` and open the fresh `embedCanvasUrl`.
 - **Version skew — fail silently:** this needs a CLI new enough to support `canvas-link`. If the installed CLI does not recognize the command (older version), skip this flow silently — do NOT treat it as an error; just surface the clean `canvasUrl` as usual.
-- **Version skew — system browser may still pop:** on CLI versions older than `0.9.0-beta.2`, `create-project` may still open the user's system browser. If the installed CLI supports it, pass `--no-open` to `create-project` to suppress that explicitly.
+- **Version skew — `--no-open`:** the `--no-open` flag exists from CLI `0.9.0-beta.2`. On older CLI versions the flag is absent and `create-project` will open the user's system browser — tolerate that silently; do NOT treat it as an error.
 
 # How it works
 

--- a/skills/superdesign/SKILL.md
+++ b/skills/superdesign/SKILL.md
@@ -84,6 +84,10 @@ Follow these steps in order — do NOT skip any step:
 
 > **Never assume the user is already logged in.** Always verify login first.
 
+## If Superdesign requests repeatedly time out
+
+If network requests to Superdesign (CLI/API calls) repeatedly time out, first CHECK WITH THE USER whether they are currently running in **Codex Web (browser) mode**. If they are, explain briefly that Codex Web's sandbox has network restrictions that can cause these timeouts, and recommend switching to the ChatGPT Codex desktop app for a reliable connection.
+
 ## Command examples
 
 Always use the full on-demand runner prefix:
@@ -117,6 +121,20 @@ Ensure `.superdesign/tmp/` is ignored by the project's `.gitignore`; append the 
 Every project/draft command's default output includes a `canvas:` link (the project canvas, `https://superdesign.dev/teams/<teamId>/projects/<projectId>`) and, for drafts, a `preview:` link (`https://superdesign.dev/preview/draft/<draftId>`). Read these from the command output — do NOT hand-construct them (the ids are server-generated).
 
 After creating a project or design draft, and at natural review moments (after `iterate-design-draft` or `execute-flow-pages`), give the user the `canvas` URL as a clickable link and invite them to open it to watch designs stream in and leave feedback. Adding `?live=1` to the canvas URL opens the live view where drafts appear as they generate.
+
+## Codex embedded canvas (Browser side panel)
+
+When you are running **inside Codex with the built-in Browser side panel available**, drop the finished design straight into that panel so the user can view and hand-tweak it immediately — no login step for them. After completing design work (a draft/flow the user is ready to look at):
+
+1. Run `npx --yes @superdesign/cli@latest canvas-link <projectId>`. It mints a single-use code and prints two URLs (with their own usage annotations): an `embedCanvasUrl` and a `canvasUrl`.
+2. Open the returned **`embedCanvasUrl`** in the Browser panel. It auto-signs-in to a restricted embedded canvas — view + manual edit only, no chat/agent, no navigation — so the user can see and manually edit the design right away, no login needed.
+
+Rules:
+
+- **The embedded canvas has no chat/agent.** All generation and iteration keep happening from THIS coding-agent session (`create-design-draft` / `iterate-design-draft` / `execute-flow-pages` as usual); the panel is a view-and-manual-edit surface only.
+- **Never surface `embedCanvasUrl` to a human or open it in a normal external browser.** It is single-use and short-lived — an agent-surface-only link. Any link you give a person, or open outside the Browser panel, MUST be the clean, durable `canvasUrl` (it requires login, like every other canvas URL you surface).
+- **The embedded session expires after 1 hour.** On expiry the user sees a panel asking them to have the agent re-open it — just re-run `canvas-link` and open the fresh `embedCanvasUrl`.
+- **Version skew — fail silently:** this needs a CLI new enough to support `canvas-link`. If the installed CLI does not recognize the command (older version), skip this flow silently — do NOT treat it as an error; just surface the clean `canvasUrl` as usual.
 
 # How it works
 

--- a/skills/superdesign/references/GRAPHIC.md
+++ b/skills/superdesign/references/GRAPHIC.md
@@ -1,6 +1,8 @@
 # Graphic Generation Workflow (posters, covers, social & marketing assets)
 
-Use this workflow when the user asks for a **static poster-like artwork** — poster, flyer, cover art, album/book cover, event visual, social media graphic, banner artwork — rather than a web page or app screen. It replaces the EXISTING UI / BRAND NEW PROJECT SOPs; everything else in `SUPERDESIGN.md` (CLI setup, login, canvas links, command contract) still applies.
+Use this workflow when the user asks for a **static poster-like artwork** — poster, flyer, cover art, album/book cover, event visual, social media graphic, banner artwork — rather than a web page or app screen. It replaces the EXISTING UI / BRAND NEW PROJECT SOPs.
+
+CLI setup and login live in `SKILL.md` (the "Superdesign CLI" and "When a command fails" sections) — follow those. From `SUPERDESIGN.md`, only these sections apply to graphics: the COMMAND CONTRACT, `upload-asset`, VERSION HISTORY & REVERT, the canvas-URL surfacing, TOOL USE RULE, and USER REQUEST PASSING. The init/design-system gates do NOT apply here: a standalone poster/marketing asset needs no repo init, no `.superdesign/init/` files, and no `design-system.md`/`globals.css` context — the brief carries the style. (Only run init and pass the design system if the user explicitly asks for on-brand output matching an existing codebase.)
 
 Core idea: **you** produce the key visual with your own image-generation tool, upload it to Superdesign, and let Superdesign compose the graphic as pixel-perfect HTML on a fixed canvas. Text is always rendered by the HTML layer, never baked into images — that is what keeps graphics sharp, editable, and iterable.
 
@@ -17,6 +19,8 @@ A graphic lives in a project like any draft. Reuse the current project or `creat
 ## Step 1 — Confirm the brief (one round, not three)
 
 Draft a concrete proposal yourself, then confirm it with the user in a SINGLE round using your question/confirmation mechanism. Skip confirmation entirely when the user already gave full specs or says to generate directly.
+
+**Folding in diverge-first:** for an open-ended request, SKILL.md's "diverge first" default (propose three distinct directions) is merged INTO this one brief-confirmation round — it is NOT a separate round. Present three distinct directions, each carrying its own **layout + style + asset plan**, while the shared items (purpose, verbatim copy, canvas) are confirmed once for all three. If the user accepts trying all three, that counts as an explicit request for three variants (generate them with `--mode branch`). For requests that already carry a clear spec, skip the divergence and confirm the single brief.
 
 Cover these five items:
 
@@ -39,15 +43,15 @@ Image tools only offer fixed size steps — match the nearest **aspect**, not ex
 
 ### Platform-specific marketing assets
 
-When the poster is a marketing asset for a specific platform (feed post, story, cover, thumbnail, ad creative), use the exact platform dimension instead of the generic presets — and MUST confirm the dimension with the user before creating; do NOT assume it.
+When the poster is a marketing asset for a specific platform (feed post, story, cover, thumbnail, ad creative), use the exact platform dimension instead of the generic presets — and MUST confirm the dimension with the user before creating; do NOT assume it. The "recommended" size for a platform with multiple options is a starting suggestion, not a default you may skip confirming.
 
 | Category  | Platform               | Asset Type            | Aspect Ratio | Recommended Size (px) |
 | --------- | ---------------------- | --------------------- | ------------ | --------------------- |
-| Feed      | Instagram              | Feed Post (Square)    | 1:1          | 1080 × 1080 (default) |
+| Feed      | Instagram              | Feed Post (Square)    | 1:1          | 1080 × 1080 (recommended, still confirm) |
 | Feed      | Instagram              | Feed Post (Portrait)  | 4:5          | 1080 × 1350           |
 | Feed      | Instagram              | Feed Post (Landscape) | 1.91:1       | 1080 × 566            |
 | Feed      | Facebook               | Feed Post             | 1.91:1       | 1200 × 630            |
-| Feed      | LinkedIn               | Feed Post             | 1:1          | 1200 × 1200 (default) |
+| Feed      | LinkedIn               | Feed Post             | 1:1          | 1200 × 1200 (recommended, still confirm) |
 | Feed      | LinkedIn               | Feed Post (Landscape) | 1.91:1       | 1200 × 627            |
 | Feed      | X / Twitter            | Post Image            | 16:9         | 1200 × 675            |
 | Feed      | Threads                | Post Image            | 1:1          | 1080 × 1080           |

--- a/skills/superdesign/references/GRAPHIC.md
+++ b/skills/superdesign/references/GRAPHIC.md
@@ -141,12 +141,10 @@ STYLE: <style adjectives, palette, font character (e.g. heavy grotesque headline
 
 Omit the KEY VISUAL block for asset-less layouts.
 
-**Fallback**: if the CLI rejects `--kind` as an unknown option (older CLI), re-run without it and append to the prompt: "This is a static fixed-canvas GRAPHIC, not a web page: no responsive prefixes (sm:/md:/lg:), no scrolling, no navigation bars, buttons, or forms."
-
 ## Step 5 — Review & iterate
 
 - Give the user the `canvas` link from the command output (and the `preview` link).
-- Iterate with `iterate-design-draft` as usual — drafts created with `--kind graphic` stay in graphic mode server-side, so plain instructions like "make the headline bigger" are safe. If you used the no-`--kind` fallback, restate the graphic constraints in EVERY iterate prompt.
+- Iterate with `iterate-design-draft` as usual — drafts created with `--kind graphic` stay in graphic mode server-side, so plain instructions like "make the headline bigger" are safe.
 - `--mode branch` works well for exploring 2-3 poster directions from the same brief and asset.
 
 ## Series (multiple graphics)

--- a/skills/superdesign/references/INIT.md
+++ b/skills/superdesign/references/INIT.md
@@ -55,18 +55,15 @@ Map out the page/route structure:
 For key pages (home, dashboard, main features), include a brief summary of what the page renders.
 
 ### 5. Write `theme.md`
-Extract the design system / theme tokens. **Include FULL file contents**, not summaries:
-- Read and include FULL CSS variable definitions (`:root`, `[data-theme]`, etc.)
-- Read and include FULL Tailwind config (`tailwind.config.*`) — especially `theme.extend`
-- Read and include any theme provider files
-- Read and include globals.css, index.css, or equivalent
-- Capture: colors, fonts, spacing scale, border radius, shadows, breakpoints
+Extract the design system / theme tokens. Structure the file in **two parts, in this order**:
 
-**IMPORTANT**: Include the COMPLETE raw files in fenced code blocks:
-- Full `tailwind.config.ts/js` content
+**Part 1 — Compact token summary (at the TOP).** A concise, readable digest of the actual values: the color palette (token name → value, incl. `:root` and `.dark`), font families and type scale, spacing scale, border-radius, shadows, and breakpoints. This summary is the budget-friendly context the design flow reaches for first — the PAYLOAD BUDGET rule in `SUPERDESIGN.md` points here to avoid passing a giant `globals.css` whole. Keep it tight enough to pass as context on its own.
+
+**Part 2 — Raw source dumps (BELOW the summary).** The complete raw files in fenced code blocks, for when the full source is needed:
+- Full `tailwind.config.ts/js` content (especially `theme.extend`)
 - Full `globals.css` / `index.css` content
-- Full CSS variable definitions
-- Any design token files
+- Full CSS variable definitions (`:root`, `[data-theme]`, etc.)
+- Any theme provider files and design token files
 
 ### 6. Write `pages.md`
 For each key page/route in the app (home, dashboard, main features — up to 10 pages), build a **complete component dependency tree** by tracing imports recursively.
@@ -96,7 +93,7 @@ Dependencies:
 - src/components/layout/Footer.tsx
 ```
 
-This tree is the **SINGLE SOURCE OF TRUTH** for which files to pass as `--context-file` when designing a page. If a file appears in the tree, it MUST be included.
+This tree is the **candidate set** of files to pass as `--context-file` when designing a page — the starting point for context selection. It is not an unconditional include-everything list: apply the PAYLOAD BUDGET rules in `SUPERDESIGN.md` when selecting (budget before the call, line-range ~900+ line files to their render/token sections, drop files with no visual bearing) so the payload does not 400.
 
 Prioritize the most important/complex pages (home, dashboard, settings, etc.). Skip trivial pages (404, offline, status).
 
@@ -155,4 +152,4 @@ This file serves as a "menu" — the design workflow reads it to decide which co
 - Keep descriptions concise — the goal is machine-readable context, not documentation
 
 ## Key Principle: INCLUDE ACTUAL CODE
-The init files should contain **actual implementation code** (.tsx, .css, .ts), not just documentation or descriptions. Superdesign needs real code to reproduce UI accurately. Be generous with the content — more context is always better than less.
+The init files should contain **actual implementation code** (.tsx, .css, .ts), not just documentation or descriptions. Superdesign needs real code to reproduce UI accurately. Be thorough and complete for the key pages and shared UI — but bounded and deduplicated, not padded. These files are the discovery layer; the actual design calls pass only the target page's necessary context under the PAYLOAD BUDGET (see `SUPERDESIGN.md`), so oversized dumps just raise reader/token cost without helping.

--- a/skills/superdesign/references/SUPERDESIGN.md
+++ b/skills/superdesign/references/SUPERDESIGN.md
@@ -2,7 +2,10 @@ You are "Superdesign Agent". Your job is to use Superdesign to generate and iter
 
 IMPORTANT: MUST produce design on superdesign, only implement actual code AFTER user approve OR the user explicitly says 'skip design and implement'
 
-⛔ HARD GATE — INIT BEFORE ANY DESIGN (real-codebase path only): When a real codebase is present, NEVER run `npx --yes @superdesign/cli@latest create-project`, `npx --yes @superdesign/cli@latest create-design-draft`, `npx --yes @superdesign/cli@latest iterate-design-draft`, or `npx --yes @superdesign/cli@latest execute-flow-pages` until `.superdesign/init/` exists with all files (init complete). If init is missing or still running, WAIT for it to finish first. Creating a project or draft before init is done is a hard error. This gate does NOT apply to the no-codebase path (empty/scratch/sandbox workspace with no frontend code — see SKILL.md Step 1): there is nothing to init, so gather design context conversationally and design directly via **SOP: BRAND NEW PROJECT** below.
+⛔ HARD GATE — INIT BEFORE ANY DESIGN (real-codebase path only): When a real codebase is present, NEVER run `npx --yes @superdesign/cli@latest create-project`, `npx --yes @superdesign/cli@latest create-design-draft`, `npx --yes @superdesign/cli@latest iterate-design-draft`, or `npx --yes @superdesign/cli@latest execute-flow-pages` until init is complete (all six files in `.superdesign/init/` exist and are non-empty — the decidable test in Task 1.1). If init is missing, incomplete, or still running, WAIT for it to finish first. Creating a project or draft before init is done is a hard error. This gate does NOT apply to:
+
+- **the no-codebase path** (empty/scratch/sandbox workspace with no frontend code — see SKILL.md Step 1): there is nothing to init, so gather design context conversationally and design directly via **SOP: BRAND NEW PROJECT** below.
+- **the graphic workflow** (`references/GRAPHIC.md`): posters/marketing assets are standalone fixed-canvas artworks that never require repo init or design-system context — UNLESS the user explicitly asks for on-brand output that matches the codebase, in which case run init first and pass the design system as usual.
 
 ## SOP: EXISTING UI
 
@@ -12,10 +15,10 @@ Collect the two workstreams below in parallel when the current agent environment
 Task 1.1 - UI Source Context:
 Superdesign agent has no context of our codebase and current UI, so first step is to identify and read the most relevant source files to pass as context.
 
-**MANDATORY FIRST STEP**: Check if `.superdesign/init/` exists with all 6 files (components.md, layouts.md, routes.md, theme.md, pages.md, extractable-components.md).
+**MANDATORY FIRST STEP — the decidable init-complete test**: Init is complete only if ALL SIX named files exist AND are non-empty: `components.md`, `layouts.md`, `routes.md`, `theme.md`, `pages.md`, `extractable-components.md`. A directory that is missing any of them, or holds an empty one (e.g. an interrupted init), is NOT complete.
 
-- **If init files are missing or incomplete**: You MUST run the full init analysis FIRST before any design work. Follow the INIT instructions from the skill to scan the repo and write all 6 files to `.superdesign/init/`. Do NOT proceed to Step 2 until init is complete.
-- **If init files exist**: Read ALL files in this directory:
+- **If init is not complete** (any of the six missing or empty): You MUST run the full init analysis FIRST before any design work. Follow the INIT instructions from the skill to scan the repo and write all six files to `.superdesign/init/`. Re-running init regenerates all six files; overwriting existing ones is expected and fine. Do NOT proceed to Step 2 until init is complete.
+- **If init is complete**: Read ALL six files in this directory:
   - components.md - shared UI primitives inventory
   - layouts.md - full source code of layout components
   - routes.md - route/page mapping
@@ -36,7 +39,7 @@ Superdesign needs ALL UI code for accurate reproduction. Include every piece of 
 - Keep: all JSX, styles, className, props, CSS, config — the complete happy-path UI as-is
 
 **HOW TO USE LINE RANGES:**
-Line ranges (`--context-file path:startLine:endLine`) should ONLY be used to **skip large blocks of pure logic** (e.g., a 100-line data-fetching hook at the top of a file). Do NOT use line ranges to trim CSS, JSX, or any visual code.
+In a file under ~900 lines, line ranges (`--context-file path:startLine:endLine`) should ONLY be used to **skip large blocks of pure logic** (e.g., a 100-line data-fetching hook at the top of a file); do NOT use them to trim CSS, JSX, or any visual code. At ~900+ lines you MUST line-range to the render/token sections — see the canonical **CONTEXT FILE LINE RANGES** table.
 
 Example: A page component with 50 lines of hooks/fetching at top, then 80 lines of JSX:
 → Use `--context-file src/pages/Dashboard.tsx:50` to skip the logic, keep all JSX from line 50 onward.
@@ -63,24 +66,16 @@ If `.superdesign/init/pages.md` exists, use it as the starting point — it pre-
 6. **Utilities**: cn/classnames — pass full file
 7. **Brand assets & icons** (see BRAND & ICON RULES below)
 
-**⚠️ 1000+ LINE FILE RULE (MANDATORY):**
-Any file exceeding ~1000 lines MUST use line ranges — no exceptions. Extract only the sections relevant to the target page:
-
-- **Large CSS files (1000+ lines)**: extract ONLY the selectors/variables actually used by the target page's components. Trace each className → find its CSS definition lines → include only those sections.
-- **Large component files with many variants**: extract ONLY the variant/branch being used on the target page, skip unused variants.
-- **Large config files**: extract only the relevant config sections.
-
-⚠️ **For normal-sized files (<1000 lines)**: pass full file by default. DO NOT trim small CSS, JSX, or config files.
-⚠️ **DO NOT trim JSX/template code** in normal-sized files. Every element matters for pixel-perfect accuracy.
-⚠️ **ONLY use line ranges to skip pure logic blocks** (data fetching, hooks, handlers) or to extract from 1000+ line files.
+**⚠️ LARGE FILE RULE (MANDATORY):**
+Follow the single canonical trimming rule in **CONTEXT FILE LINE RANGES** below (threshold ~900 lines). In short: any file ~900 lines or more MUST use line ranges — no exceptions — extracting only the sections relevant to the target page (a CSS file's used selectors/variables, a component's used variant/branch, a config's relevant block). Files under ~900 lines pass full; the ONLY line-ranging allowed in a small file is skipping a pure-logic block. Never trim JSX/template or other visual code in a small file — every element matters for pixel-perfect accuracy.
 
 **🚨 PAYLOAD BUDGET — BUDGET OR FAIL, NEVER THIN-RETRY (the #1 cause of garbage reproductions):**
 The design API rejects oversized context with a **400**. When that happens and the agent "retries with less," the real page never reaches the model and it **invents a generic on-brand page from `design-system.md`** — total garbage. Prevent it:
 
-1. **Budget BEFORE the call.** Sum the lines of your `--context-file` set. A big page often pulls in a 1000+ line shared header + the 1000+ line page + a 900+ line `globals.css` — that combination WILL 400. Keep the set lean:
-   - **Shared shell/header/nav (1000+ lines): line-range to its render section only** (e.g. the `<header>` JSX `:452:1247`, not the 1249-line whole file). Skip the hooks/handlers/menus above the render.
-   - **The target page (1000+ lines): line-range to the render branch that actually renders** (e.g. the desktop `!isMobile` block `:697:935`), not the whole multi-branch file.
-   - **`globals.css` (900+ lines): do NOT pass it whole.** Prefer `.superdesign/init/theme.md` (the token summary) for the values; or line-range globals to its `:root`/`.dark` token block only.
+1. **Budget BEFORE the call.** Sum the lines of your `--context-file` set. A big page often pulls in a ~900+ line shared header + the ~900+ line page + a ~900+ line `globals.css` — that combination WILL 400. Apply the canonical ~900-line threshold (see **CONTEXT FILE LINE RANGES**) and keep the set lean:
+   - **Shared shell/header/nav (~900+ lines): line-range to its render section only** (e.g. the `<header>` JSX `:452:1247`, not the 1249-line whole file). Skip the hooks/handlers/menus above the render.
+   - **The target page (~900+ lines): line-range to the render branch that actually renders** (e.g. the desktop `!isMobile` block `:697:935`), not the whole multi-branch file.
+   - **`globals.css` (~900+ lines): do NOT pass it whole.** Prefer the compact token summary at the top of `.superdesign/init/theme.md` for the values; or line-range globals to its `:root`/`.dark` token block only.
 2. **On a 400: trim the BIG files to their render sections and retry the SAME faithful call.** NEVER retry with a thinned/minimal context just to make the call succeed — a reproduction off thin context is invention, not reproduction. If you cannot fit the real page, STOP and tell the user; do not ship an invented draft.
 3. **Prefer a self-contained page when the user is flexible.** A page that is one big UI component (no giant shared-shell dependency) reproduces faithfully and fits the budget; a shell-dependent page requires the line-ranging above. (A self-contained `/detail` page reproduced cleanly where a shell-dependent `/list` page 400'd — same model, only the payload differed.)
 
@@ -167,10 +162,10 @@ Step 3 — Design in Superdesign
     --context-file src/lib/cn.ts
   ```
 
-  **Line range usage:**
+  **Line range usage** (per the canonical ~900-line threshold in **CONTEXT FILE LINE RANGES**):
   - Most files: pass **full file** (default — preserves all UI details)
   - Large page components with heavy logic at top: skip the logic block — e.g. `Target.tsx:45` skips 44 lines of data fetching, keeps all JSX from line 45
-  - **NEVER trim CSS, config, or pure UI component files** — always pass full
+  - **For files under ~900 lines, NEVER trim CSS, config, or pure UI component files** — always pass full. At ~900+ lines, line-range to the render/token sections (the only sanctioned way to trim visual code).
 
   ⚠️ This step produces ONE draft with ONE -p. The -p must ONLY ask for pixel-perfect reproduction, NO design changes.
 
@@ -181,7 +176,7 @@ Step 3 — Design in Superdesign
   **VARIANT COUNT RULE**:
   - Default: generate exactly **2** variations (2 `-p` flags) unless the user specifies otherwise.
   - If the user explicitly requests or describes only **1** variation, generate exactly **1** `-p`. Do NOT invent extra variations the user didn't ask for.
-  - Only generate 3+ variations if the user explicitly asks for more.
+  - Only generate 3+ variations if the user explicitly asks for more. **Accepting the diverge-first "try all three directions" recommendation counts as explicitly asking for 3** — when the user says yes to that offer, generate the three as parallel variants.
 
   ```
   npx --yes @superdesign/cli@latest iterate-design-draft --draft-id <draft-id-from-3a> \
@@ -212,7 +207,7 @@ Step 3 — Design in Superdesign
 - ❌ Putting multiple design variations into a single create-design-draft -p (create-design-draft only accepts ONE -p, and it should be reproduction only)
 - ❌ Using create-design-draft for variations — use iterate-design-draft --mode branch instead
 - ❌ Combining "reproduce current UI + try 4 new designs" in one step — these are ALWAYS two separate steps
-- ❌ **Trimming CSS/JSX/config files with line ranges** — NEVER trim visual code. Only use line ranges to skip data-fetching blocks
+- ❌ **Trimming CSS/JSX/config files under ~900 lines with line ranges** — NEVER trim visual code in a small file; only use line ranges there to skip data-fetching blocks. At ~900+ lines, line-range to the render/token sections (the only sanctioned way to trim visual code — see CONTEXT FILE LINE RANGES)
 - ❌ **Missing key files** — trace imports to find all UI-touching files. Missing a layout or CSS file = broken reproduction
 - ❌ **Stripping conditional UI inside the main render** — `{x && <Y/>}` and ternaries are visual details, NOT edge cases. Keep them all
 - ❌ **Generating too many or too few variants** — default is 2 variants in branch mode; only 1 if the user describes a single direction; 3+ only if user explicitly asks
@@ -226,7 +221,7 @@ Extension after approval:
 
 Step 1 — Requirements gathering: ask the user using the session's available user-input mechanism; if none is available, ask in chat
 
-Step 2 — Design system setup (MUST follow Section B):
+Step 2 — Design system setup (MUST follow the **DESIGN SYSTEM SETUP** section below):
 
 - **Pick ONE primary style source — do NOT blend two competing styles:**
   - **If the user named a reference site** ("… in the style of `<site>`", "use `<site>`'s design"): that site's extracted `design.md` is the style source (extract step below). `search-prompts` is then OPTIONAL — do NOT layer a library style prompt on top of the extracted DNA (two competing styles dilute the result).
@@ -282,7 +277,7 @@ Without explicit constraints, the Superdesign design agent will invent random fo
 To prevent this:
 
 1. **ALWAYS pass `--context-file .superdesign/design-system.md`** on EVERY iterate-design-draft and create-design-draft call
-2. **ALWAYS pass `--context-file <path-to-globals.css>`** on EVERY call — this contains the actual CSS tokens
+2. **ALWAYS pass the globals.css tokens** on EVERY call — this contains the actual CSS tokens. Pass the file whole when it is under ~900 lines; at ~900+ lines pass its `:root`/`.dark` token block (line-ranged) or the token summary from `.superdesign/init/theme.md` instead (see the canonical rule in CONTEXT FILE LINE RANGES / PAYLOAD BUDGET)
 3. **ALWAYS append the fidelity constraint** to every -p prompt (see above)
 4. **Be explicit about what MUST stay the same** — e.g. "keep Inter as the font family, use black/white primary palette, amber/orange brand gradients only"
 
@@ -294,9 +289,9 @@ When using execute-flow-pages:
 
 ## TOOL USE RULE
 
-Default tool while iterating design of a specific page is iterate-design-draf
+Default tool while iterating design of a specific page is iterate-design-draft
 Default mode is branch
-You may ONLY use replace if user request a tiny tweak, you can describe it in one sentence and user is okay overwriting the previous version.
+You may use replace in two cases: (1) the user requests a tiny tweak you can describe in one sentence and is okay overwriting the previous version; (2) the one-round post-generation self-review fix pass (see SKILL.md "After generating") — that agent-initiated fix corrects the just-generated draft in place, so it uses `--mode replace` (never spend a variant branching a flaw you are fixing). Both cases are single-`-p`, one round only.
 Default tool while generating new pages based on an existing confirmed page is execute-flow-pages
 
 <example>
@@ -358,16 +353,17 @@ Every draft keeps a version history. The CLI's default output already self-discl
 
 - Design system file path is fixed: .superdesign/design-system.md
 - design-system.md = ALL design specs
-- **MANDATORY INIT (real-codebase path)**: When a real codebase is present, if `.superdesign/init/` is missing or incomplete you MUST run the full init analysis FIRST (follow the INIT instructions from the skill); if it exists, you MUST read ALL files (components.md, layouts.md, routes.md, theme.md, pages.md, extractable-components.md) at the START of every design task. This is NOT optional. On the no-codebase path (empty/scratch/sandbox workspace, no frontend code — see SKILL.md Step 1), there is nothing to init: skip it and gather design context conversationally instead.
+- **MANDATORY INIT (real-codebase path)**: When a real codebase is present, if init is not complete (any of the six files — components.md, layouts.md, routes.md, theme.md, pages.md, extractable-components.md — missing or empty, per the decidable test in Task 1.1) you MUST run the full init analysis FIRST (follow the INIT instructions from the skill); if it is complete, you MUST read ALL six files at the START of every design task. This is NOT optional. Two exemptions: on the no-codebase path (empty/scratch/sandbox workspace, no frontend code — see SKILL.md Step 1) there is nothing to init, so skip it and gather design context conversationally; and the graphic workflow (`references/GRAPHIC.md`) needs no init for standalone posters/marketing assets unless the user explicitly asks for on-brand output matching the codebase.
 - **MANDATORY CONTEXT FILES on EVERY design command** (create-design-draft, iterate-design-draft, execute-flow-pages):
   - Always pass `--context-file .superdesign/design-system.md` so the design agent knows the allowed fonts, colors, and spacing.
-  - On the real-codebase path, also pass `--context-file <path-to-globals.css>` when that file exists so the design agent has the actual CSS tokens and variables.
+  - On the real-codebase path, also pass the globals.css tokens (whole under ~900 lines, else its `:root`/`.dark` block or theme.md token summary — see PAYLOAD BUDGET) when that file exists so the design agent has the actual CSS tokens and variables.
   - On the no-codebase path, `globals.css` is not required; do not invent one solely to satisfy this rule.
+  - **Graphic-workflow exemption**: standalone posters/marketing assets (`references/GRAPHIC.md`) require NO `design-system.md` or `globals.css` context — the brief carries the style. Only pass the design system when the user explicitly asks for on-brand output matching the codebase.
 - **DESIGN SYSTEM = HARD CONSTRAINT, NOT SUGGESTION**: Iteration prompts explore layout/structure/content direction, NOT visual style. The design system defines the visual style. Never let a -p prompt override the design system.
-- **ALL UI CODE, STRIP ONLY DATA-FETCHING**: Pass all UI-related files with complete visual code. Use line ranges ONLY to skip data-fetching blocks or to extract from 1000+ line files. Keep ALL conditional rendering, state, props, and JSX.
-- **1000+ LINE FILES MUST USE LINE RANGES.** Extract only the sections relevant to the target page. This applies to large CSS files, large component libraries, and large configs.
+- **ALL UI CODE, STRIP ONLY DATA-FETCHING**: Pass all UI-related files with complete visual code. Use line ranges ONLY to skip data-fetching blocks or to extract from ~900+ line files (see CONTEXT FILE LINE RANGES). Keep ALL conditional rendering, state, props, and JSX.
+- **~900+ LINE FILES MUST USE LINE RANGES.** Extract only the sections relevant to the target page. This applies to large CSS files, large component libraries, and large configs. See the canonical threshold and decision table in CONTEXT FILE LINE RANGES.
 - **TRACE ALL UI FILES.** Use import tracing to find all files that touch UI. Include them with full UI code. For large mixed files (logic + UI), use line ranges to skip the logic portion only.
-- **VARIANT COUNT**: Default to **2** variations in branch mode. If the user describes only **1** direction, generate exactly **1**. Only generate 3+ if the user explicitly requests more. Never invent extra variations.
+- **VARIANT COUNT**: Default to **2** variations in branch mode. If the user describes only **1** direction, generate exactly **1**. Only generate 3+ if the user explicitly requests more — and the user accepting the diverge-first "try all three directions" recommendation counts as that explicit request for 3. Never invent extra variations otherwise.
 - Prefer iterating existing design draft over creating new ones.
 - When designing for existing UI, MUST pass relevant source files via --context-file to give Superdesign real codebase context
 - **PIXEL-PERFECT GROUND TRUTH FIRST**: For existing UI, ALWAYS create a 100% pixel-perfect reproduction draft (Step 3a) before making design changes (Step 3b). The reproduction must match EXACTLY — sizes, colors, spacing, fonts, shadows, border-radius. Never skip straight to redesign. Never combine reproduction and design changes in one command.
@@ -381,7 +377,9 @@ Every draft keeps a version history. The CLI's default output already self-discl
 
 ---
 
-## CONTEXT FILE LINE RANGES
+## CONTEXT FILE LINE RANGES — CANONICAL TRIMMING RULE
+
+**This is the single source of truth for when to trim a `--context-file`. Every other "trim" / "NEVER trim" / large-file mention in this skill defers to this table. The threshold is ~900 lines.**
 
 `--context-file` supports an optional `:startLine:endLine` suffix to include only specific portions of a file:
 
@@ -393,23 +391,15 @@ Every draft keeps a version history. The CLI's default output already self-discl
 
 Multiple ranges from the same file are automatically merged into a single context entry with omission markers between non-contiguous ranges.
 
-**Default is FULL FILE** for normal-sized files. Use line ranges in two cases: skipping pure logic, or extracting from very large files.
+**Decision table:**
 
-**When to use line ranges:**
+| File size | What to pass |
+| --- | --- |
+| **Under ~900 lines** | FULL file. NEVER trim CSS, JSX/template, config, or any other visual code. The only line-ranging allowed here is skipping a large pure-logic block (data fetching / hooks / handlers) — e.g. `src/pages/Dashboard.tsx:60` keeps all JSX from line 60. |
+| **~900 lines or more (MANDATORY)** | Line-range to the sections that matter — this is the ONLY sanctioned way to "trim visual code". For a page/component: the render branch that actually renders. For CSS: the used selectors + the `:root`/`.dark` token block (e.g. `globals.css:1:120` for variables + `globals.css:800:900` for used component styles). For config: the relevant block. |
+| **`globals.css` ~900+ lines** | Do NOT pass whole. Prefer the compact token summary at the top of `.superdesign/init/theme.md`, or line-range globals to its `:root`/`.dark` token block only. |
 
-1. **Pure logic blocks** — page components with data-fetching/hooks at the top, skip the logic, keep all JSX
-   - e.g. `--context-file src/pages/Dashboard.tsx:60` — skips 59 lines of hooks/fetching, keeps JSX from line 60
-2. **1000+ line files (MANDATORY)** — always extract only the relevant sections:
-   - Large CSS files: extract only selectors used by target page — e.g. `--context-file src/styles/globals.css:1:120` for CSS variables + `--context-file src/styles/globals.css:800:900` for relevant component styles
-   - Large component libraries: extract only the variant/component actually used
-   - Large config files: extract relevant config block
-
-**When to use full files (DEFAULT):**
-
-- Normal-sized files (<1000 lines) — always full
-- ALL UI components (Button, Card, Nav, Sidebar, etc.) — always full
-- ALL layout files — always full
-- Any file where UI and logic are interleaved (safer to include everything)
+Files that are always FULL when under ~900 lines: ALL UI components (Button, Card, Nav, Sidebar, etc.), ALL layout files, and any file where UI and logic are interleaved (safer to include everything).
 
 ---
 
@@ -525,7 +515,8 @@ Marketing assets (feed posts, stories, covers, thumbnails, ad creatives) are sta
 
 Every command supports `--json` for the full machine-readable payload; the default output is agent-optimized (TOON + `help[]`). Only the flags below `--json` (e.g. `--full`, `--user-request`) are per-command.
 
-- create-project: required `--title`; optional `--template <path>`, `--device <mobile|tablet|desktop>` (default: desktop), `--extend-from <projectId>`, `--json`
+- create-project: required `--title`; optional `--template <path>`, `--device <mobile|tablet|desktop>` (default: desktop), `--extend-from <projectId>`, `--no-open`, `--json`. By default the created project opens in the user's system browser; pass `--no-open` to suppress that (the canvas URL is always printed either way). Pass `--no-open` whenever you, the agent, are running the command rather than a human at the shell (see SKILL.md).
+- canvas-link: required `<projectId>` positional; optional `--json`. Mints a self-signing embedded-canvas link for an agent browser plus a clean shareable URL, and prints both — it does NOT open a browser. Returns `embedCanvasUrl` (agent-surface only) and `canvasUrl` (the clean login-gated URL to give a human). Used by the Codex embedded-canvas flow in SKILL.md.
 - iterate-design-draft:
   - required `--draft-id`, `-p`/`--prompt`, and `--mode <branch|replace>`; optional `--context-file` (one or more paths; supports `path:startLine:endLine`), `--model`, `--user-request <text>`, `--json`
   - branch: can include multiple `-p` prompts; optional `--count <1-4>` is valid only with a single prompt
@@ -540,7 +531,7 @@ Every command supports `--json` for the full machine-readable payload; the defau
   - --kind graphic switches generation to the fixed-canvas graphic branch (static artwork, no responsive layout) and keeps iterations in graphic mode; pair it with --width/--height. See `references/GRAPHIC.md`.
 - upload-asset: required `<file>` positional (png/jpeg/webp/gif, max 10MB) and `--project-id`; optional `--no-canvas`, `--json`. Uploads a project image asset and returns a public `url` to reference from create/iterate prompts (e.g. a poster key visual). By default the asset is also placed on the project canvas as an image node (response includes its `nodeId`); pass `--no-canvas` to skip.
 - revert-design-draft: required `--draft-id`, `--to-version <n>`; optional `--json`. Restores a prior version as the current head with NO generation; reversible (the current head is snapshotted into history first). Discover version numbers via `get-design`.
-- execute-flow-pages: required `--draft-id`, `--pages`; optional `--context`, `--context-file` (one or more paths; supports `path:startLine:endLine`), `--model`, `--json`
+- execute-flow-pages: required `--draft-id`, `--pages`; optional `--context <text>` (free-text additional context for the flow generation — a prose string, distinct from `--context-file` which passes source files), `--context-file` (one or more paths; supports `path:startLine:endLine`), `--model`, `--json`
 - get-design: required `--draft-id`; optional `--json`, `--output <path>`
 - create-component: required `--project-id`, `--name` (PascalCase), and exactly one of `--html` or `--html-file`; optional `--description`, `--props` (JSON array), `--slots` (JSON array), `--events` (JSON array), `--css-imports` (JSON array), `--json`
 - update-component: required `--component-id`; optional `--name`, `--html` or `--html-file` (not both), `--description`, `--props` (JSON array), `--slots` (JSON array), `--events` (JSON array), `--css-imports` (JSON array), `--json`


### PR DESCRIPTION
## What

Two additions to the shipped `superdesign` skill (`skills/superdesign/SKILL.md`), both English-only prose, matching the file's existing tone/format.

### 1. Codex embedded canvas (`canvas-link`)
New subsection under **Surface the canvas URL**. When the agent runs inside Codex with the built-in Browser side panel, after finishing design work it runs `canvas-link <projectId>` and opens the returned `embedCanvasUrl` in the Browser panel so the user can view + manually edit the design immediately, no login. Guidance covers:
- The embedded canvas has no chat/agent - generation/iteration keep happening from the coding-agent session.
- Only the clean, durable `canvasUrl` is ever surfaced to a human or opened in a normal browser; `embedCanvasUrl` is single-use, short-lived, agent-surface-only.
- The embedded session expires after 1 hour; on expiry the agent just re-runs `canvas-link`.
- Written defensively for version skew: if the installed CLI doesn't support `canvas-link`, skip the flow silently rather than erroring.

### 2. Network-timeout troubleshooting note
Short note in the CLI section: if Superdesign calls repeatedly time out, check with the user whether they are in Codex Web (browser) mode, and if so recommend switching to the ChatGPT Codex desktop app (Codex Web's sandbox has network restrictions that cause these timeouts).

## Notes for reviewer

- ⚠️ **HOLD until the next CLI release.** The embedded-canvas section depends on the upcoming Superdesign CLI release that adds the `canvas-link` command. It is merged to platform main but is **not yet on npm** (verified: `@superdesign/cli@beta` does not yet expose `canvas-link`). Please hold merge until that release is published, so the skill never instructs agents to run a command their installed CLI lacks. (The version-skew guidance also makes the flow safe if an older CLI is in use.)
- The network-timeout note has no such dependency and is safe today.
- `canvas-link` was intentionally **not** added to the `COMMAND CONTRACT` flag reference in `references/SUPERDESIGN.md`: per the repo's ground-truth rule the contract must be verified against the published CLI, and this command isn't published yet. Its own output carries usage annotations, and SKILL.md documents the single invocation form.
- No version bump: recent feature PRs (poster, extract-website) did not bump `.codex-plugin/plugin.json`, so per repo convention this doesn't either.
