### PR TITLE
Adopt Google Labs DESIGN.md format (replaces theme.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,12 @@ A published agent **skill** (`skills/superdesign/`) that drives the SuperDesign 
 - `skills/superdesign/SKILL.md` - entry point (front-matter + core workflow)
 - `skills/superdesign/references/SUPERDESIGN.md` - full design workflow + `COMMAND CONTRACT`
 - `skills/superdesign/references/INIT.md` - repo-analysis (init) instructions
+- `skills/superdesign/references/DESIGNMD-SPEC.md` - pinned, verbatim snapshot of Google Labs' DESIGN.md format spec (Apache-2.0). See "Design tokens layer" below.
 - `skills/superdesign/{SUPERDESIGN,INIT}.md` - deprecated compatibility forwarders (do not add content)
+
+## Design tokens layer: DESIGN.md, not theme.md
+
+The skill's theme/token context is the interoperable **DESIGN.md** format (Google Labs), not the old `theme.md`. INIT.md step 5 is the source of truth: detect a project `DESIGN.md` (repo root, then `docs/`); consume a valid one READ-ONLY (NEVER overwrite it - duplicate `##` section headings = invalid per spec, fall back to a generated `.superdesign/init/DESIGN.md`); generate one at repo root when the project has none. Raw CSS/Tailwind dumps live in the `theme-raw.md` sidecar, not inside DESIGN.md. DESIGN.md = visual-identity layer; `components/layouts/routes/pages/extractable-components.md` stay the code-context layer. The init-complete predicate (SKILL.md, SUPERDESIGN.md Task 1.1) counts a "DESIGN.md slot" = valid DESIGN.md available + `theme-raw.md` exists. `DESIGNMD-SPEC.md` carries its own upstream URL/commit/version attribution header; re-vendor from `raw.githubusercontent.com/google-labs-code/design.md/main/docs/spec.md` (verbatim body + refreshed header) when syncing - do NOT add a runtime dep on any DESIGN.md CLI.
 
 ## Skill flow invariant: two entry paths
 

--- a/skills/superdesign/SKILL.md
+++ b/skills/superdesign/SKILL.md
@@ -62,7 +62,7 @@ When a real codebase is present (per Step 1) and init is NOT complete, you MUST 
 2. Read `references/INIT.md` relative to this selected `SKILL.md`
 3. Follow its instructions to analyze the repo and write context files
 
-**Init-complete test (one decidable rule, used everywhere):** init is complete only if all six named files below exist AND are non-empty. A directory that is missing any of them, or holds an empty one (e.g. an interrupted init), is NOT complete — rerun the full init, which regenerates all six; overwriting existing files is expected and fine.
+**Init-complete test (one decidable rule, used everywhere):** init is complete only if all six init slots below are satisfied AND non-empty. Five are files in `.superdesign/init/`; the sixth is the DESIGN.md slot — a valid `DESIGN.md` available (the project's own, or the one init generated) plus its `theme-raw.md` sidecar (see `references/INIT.md` step 5 for the full rule). A slot that is missing, or an empty file (e.g. an interrupted init), is NOT complete — rerun the full init, which regenerates our own files; overwriting them is expected and fine, but init NEVER overwrites a pre-existing valid project `DESIGN.md` (it consumes that read-only).
 
 Do NOT ask the user to do this manually — just do it.
 
@@ -73,11 +73,11 @@ If init is complete (all six files present and non-empty), you MUST read ALL of 
 - `components.md` — shared UI primitives with full source code
 - `layouts.md` — shared layout components (nav, sidebar, header, footer)
 - `routes.md` — page/route mapping
-- `theme.md` — design tokens, CSS variables, Tailwind config
+- `DESIGN.md` — normative design tokens (YAML front matter) + design rationale, in the interoperable DESIGN.md format (detection order: repo root, then `docs/`, then `.superdesign/init/`); its `theme-raw.md` sidecar holds the raw CSS/Tailwind dumps. See `references/DESIGNMD-SPEC.md`.
 - `pages.md` — page component dependency trees (which files each page needs)
 - `extractable-components.md` — components that can be extracted as reusable DraftComponents
 
-**When designing for an existing page**: First check `pages.md` for the page's dependency tree — the candidate set of `--context-file` files. Pass them under the PAYLOAD BUDGET rules in `references/SUPERDESIGN.md` (line-range ~900+ line files to their render/token sections; drop files with no visual bearing) so the payload does not 400. Then also add the globals.css tokens, tailwind.config, and design-system.md.
+**When designing for an existing page**: First check `pages.md` for the page's dependency tree — the candidate set of `--context-file` files. Pass them under the PAYLOAD BUDGET rules in `references/SUPERDESIGN.md` (line-range ~900+ line files to their render/token sections; drop files with no visual bearing) so the payload does not 400. Then also add the design tokens (the `DESIGN.md` YAML front matter, or the globals.css `:root`/`.dark` block), tailwind.config, and design-system.md.
 
 # Superdesign CLI (MUST use before any command)
 

--- a/skills/superdesign/references/DESIGNMD-SPEC.md
+++ b/skills/superdesign/references/DESIGNMD-SPEC.md
@@ -1,0 +1,390 @@
+<!--
+Vendored snapshot of the DESIGN.md format specification.
+
+Vendored unmodified from google-labs-code/design.md (docs/spec.md) under Apache-2.0.
+
+Upstream URL:    https://github.com/google-labs-code/design.md/blob/main/docs/spec.md
+Raw source:      https://raw.githubusercontent.com/google-labs-code/design.md/main/docs/spec.md
+Upstream commit: bde692f2bc92ef7fdd0cf277b2704ab074b70efd
+Fetched:         2026-07-22
+Spec version:    alpha
+License:         Apache-2.0 (https://github.com/google-labs-code/design.md/blob/main/LICENSE)
+
+This is a pinned local snapshot. Agents consult this file directly instead of
+fetching the network or running any DESIGN.md CLI. Everything below the header
+delimiter is the upstream spec, reproduced verbatim.
+-->
+
+<!-- ===== BEGIN VENDORED UPSTREAM: docs/spec.md ===== -->
+
+<!-- Generated from spec.mdx + spec-config.ts | version: alpha -->
+<!-- Do not edit directly. Run `bun run spec:gen` to regenerate. -->
+
+# DESIGN.md Format
+
+DESIGN.md is a self-contained, plain-text representation of a design system. It defines the visual identity of a brand and product, thereby ensuring that these stylistic choices can be followed across design sessions and between different AI agents and tools.  As a human-readable, open-format document, it serves as a living source of truth that both humans and AI can understand and refine.
+
+A DESIGN.md file contains two parts: An optional YAML frontmatter, and a markdown body. The YAML front matter contains machine-readable design tokens. The markdown body sections provide human-readable design rationale and guidance. Prose may use descriptive color names (e.g., "Midnight Forest Green") that correspond to systematic token names (e.g., `primary`). The tokens are the normative values; the prose provides context for how to apply them.
+
+# Design Tokens
+
+DESIGN.md may embed design tokens in a structured format. The system that we use to describe design tokens is inspired by the
+[Design Token JSON spec](https://www.designtokens.org/tr/2025.10/format/#abstract). Specifically, we adopt the concept of typed token groups (colors, typography, spacing) and the `{path.to.token}` reference syntax for cross-referencing values.
+
+These tokens are easily converted from or to `tokens.json`, Figma variables, and Tailwind theme configs.
+
+Design tokens are embedded as YAML front matter at the beginning of the file. The front matter block must begin with a line containing exactly `---` and end with a line containing exactly `---`. The YAML content between these delimiters is parsed according to the schema defined below.
+
+Example:
+
+```yaml
+---
+version: alpha
+name: Daylight Prestige
+colors:
+  primary: "#1A1C1E"
+  secondary: "#6C7278"
+  tertiary: "#B8422E"
+typography:
+  h1:
+    fontFamily: Public Sans
+    fontSize: 48px
+    fontWeight: 600
+    lineHeight: 1.1
+    letterSpacing: -0.02em
+---
+```
+
+## Schema
+
+Below is the schema for the design tokens defined in the front matter:
+
+```yaml
+version: <string>          # optional, current version: "alpha"
+name: <string>
+description: <string>      # optional
+colors:
+  <token-name>: <Color>
+typography:
+  <token-name>: <Typography>
+rounded:
+  <scale-level>: <Dimension>
+spacing:
+  <scale-level>: <Dimension | number>
+components:
+  <component-name>:
+    <token-name>: <string|token reference>
+```
+
+The `<scale-level>` placeholder represents a named level in a sizing or spacing scale. Common level names include `xs`, `sm`, `md`, `lg`, `xl`, and `full`. Any descriptive string key is valid.
+
+**Color**: A color value is any valid CSS color string.
+
+Supported formats include:
+
+- Hex: `#RGB`, `#RGBA`, `#RRGGBB`, `#RRGGBBAA`
+- Named colors: `red`, `cornflowerblue`, `transparent`
+- Functional: `rgb()`, `rgba()`, `hsl()`, `hsla()`, `hwb()`
+- Wide-gamut: `oklch()`, `oklab()`, `lch()`, `lab()`
+- Mixing: `color-mix(in srgb, ...)`
+
+All color values are internally converted to sRGB for WCAG contrast checking. The original format is preserved for display and export.
+
+Hex notation (`#RRGGBB`) remains the recommended default for simplicity and broad tooling support.
+
+**Dimension**: A dimension value is a string with a unit suffix.
+
+Valid units are: px, em, rem.
+
+- `fontFamily` (string)
+- `fontSize` (Dimension)
+- `fontWeight` (number) - A numeric font weight value (e.g., `400`, `700`). In YAML, this may be expressed as either a bare number or a quoted string; both are equivalent.
+- `lineHeight` (Dimension | number) - Accepts either a Dimension (e.g., `24px`, `1.5rem`) or a unitless number (e.g., `1.6`). A unitless number represents a multiplier of the element's `fontSize`, which is the recommended CSS practice.
+- `letterSpacing` (Dimension)
+- `fontFeature` (string) - configures
+  [`font-feature-settings`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/font-feature-settings).
+- `fontVariation` (string) - configures
+  [`font-variation-settings`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/font-variation-settings).
+
+**Token References**: A token reference must be wrapped in curly braces, and contain an object path to another value in the YAML tree. For most token groups, the reference must point to a primitive value (e.g., `colors.primary-60`), not a group (e.g., `colors`). Within the `components` section, references to composite values (e.g., `{typography.label-md}`) are permitted.
+
+# Sections
+
+Every `DESIGN.md` follows the same structure. Sections can be omitted if they're not relevant to your project, but those present should appear in the sequence listed below. All sections use `<h2>` (`##`) headings. An optional `<h1>` heading may appear for document titling purposes but is not parsed as a section.
+
+### Section Order
+
+1. **Overview** (also: "Brand & Style")
+2. **Colors**
+3. **Typography**
+4. **Layout** (also: "Layout & Spacing")
+5. **Elevation & Depth** (also: "Elevation")
+6. **Shapes**
+7. **Components**
+8. **Do's and Don'ts**
+
+### Prose and Tokens
+
+## Overview
+
+Also known as "Brand & Style".
+
+This section is a holistic description of a product's look and feel. It defines the brand personality, target audience, and the emotional response the UI should evoke, such as whether it should feel playful or professional, dense or spacious. It serves as foundational context for guiding the agent's high-level stylistic decisions when a specific rule or token isn't explicitly defined.
+
+## Colors
+
+This section defines the color palettes for the design system.
+
+At least the `primary` color palette must be defined, and additional color palettes may be defined as needed.
+
+When there are multiple color palettes, the design system may assign a semantic role for each palette. A common convention is to name the palettes in this order: `primary`, `secondary`, `tertiary`, and `neutral`.
+
+Example:
+
+```markdown
+## Colors
+
+The palette is rooted in high-contrast neutrals and a single, evocative accent color.
+
+- **Primary (#1A1C1E):** A deep ink used for headlines and core text to provide
+  maximum readability and a sense of permanence.
+- **Secondary (#6C7278):** A sophisticated slate used primarily for utilitarian
+  elements like borders, captions, and metadata.
+- **Tertiary (#B8422E):** A vibrant earthy red as the sole driver for
+  interaction, used exclusively for primary actions and critical highlights.
+- **Neutral (#F7F5F2):** A warm limestone that serves as the foundation for all
+  pages, providing a softer, more organic feel than pure white.
+```
+
+### Design Tokens
+
+The `colors` section defines all color design tokens. The color tokens should be derived from the key color palettes defined in the markdown prose. The exact mapping from color palettes to color tokens may follow any consistent naming convention.
+
+It is a
+map\<string, Color>, that maps the name of the color token to its value.
+
+```yaml
+colors:
+  primary: "#1A1C1E"
+  secondary: "#6C7278"
+  tertiary: "#B8422E"
+  neutral: "#F7F5F2"
+```
+
+## Typography
+
+This section defines typography levels.
+
+Most design systems have 9 - 15 typography levels. The design system may prescribe a role for each typography level.
+
+A common naming convention for typography levels is to use semantic categories such as `headline`, `display`, `body`, `label`, `caption`. Each category may further be divided into different sizes, such as `small`, `medium`, and `large`.
+
+Example:
+
+```markdown
+## Typography
+
+The typography strategy leverages two distinct weights of **Public Sans** for
+the narrative and **Space Grotesk** for technical data.
+
+- **Headlines:** Set in Public Sans Semi-Bold to establish an institutional
+  and trustworthy voice.
+- **Body:** Public Sans Regular at 16px ensures contemporary professionalism
+  and long-form readability.
+- **Labels:** Space Grotesk is used for all technical data, timestamps, and
+  metadata. Its geometric construction evokes the precision of a digital
+  stopwatch. Labels are strictly uppercase with generous letter spacing.
+```
+
+### Design Tokens
+
+The `typography` section defines the precise font properties for the typography design tokens.
+
+It is a
+map\<string, Typography>
+
+```yaml
+typography:
+  h1:
+    fontFamily: Public Sans
+    fontSize: 48px
+    fontWeight: 600
+    lineHeight: 1.1
+    letterSpacing: -0.02em
+  body-md:
+    fontFamily: Public Sans
+    fontSize: 16px
+    fontWeight: 400
+    lineHeight: 1.6
+  label-caps:
+    fontFamily: Space Grotesk
+    fontSize: 12px
+    fontWeight: 500
+    lineHeight: 1
+    letterSpacing: 0.1em
+```
+
+## Layout
+
+Also known as "Layout & Spacing".
+
+This section describes the layout and spacing strategy.
+
+Many design systems follow a grid-based layout. Others, like Liquid Glass, use margins, safe areas, and dynamic padding.
+
+Example:
+
+```markdown
+## Layout
+
+The layout follows a **Fluid Grid** model for mobile devices and a
+**Fixed-Max-Width Grid** for desktop (max 1200px).
+
+A strict 8px spacing scale (with a 4px half-step for micro-adjustments) is used to maintain a consistent rhythm. Components are grouped using "containment" principles, where related items are housed in cards with generous internal padding (24px) to emphasize the soft, approachable nature of the brand.
+```
+
+### Design Tokens
+
+The spacing section defines the spacing design tokens. These may include spacing units that are useful for implementing the layout model. For example, a fixed grid layout may have spacing units for column spans, gutters, and margins.
+
+It is a
+map\<string, Dimension | number> that maps the spacing scale identifier to a dimension value or a unitless number (e.g., column counts or ratios).
+
+```yaml
+spacing:
+  base: 16px
+  xs: 4px
+  sm: 8px
+  md: 16px
+  lg: 32px
+  xl: 64px
+  gutter: 24px
+  margin: 32px
+```
+
+## Elevation & Depth
+
+Also known as "Elevation".
+
+This section describes how visual hierarchy is conveyed based on the design style. If elevation is used, it defines the required styling (spread, blur, color). For flat designs, this section explains the alternative methods used to convey visual hierarchy (e.g., borders, color contrast).
+
+Example:
+
+```markdown
+## Elevation & Depth
+
+Depth is achieved through **Tonal Layers** rather than heavy shadows. The
+background uses a soft off-white or very light green, while primary content sits on pure white cards.
+```
+
+## Shapes
+
+This section describes how visual elements are shaped.
+
+Example:
+
+```markdown
+## Shapes
+
+The shape language is defined by **Architectural Sharpness**. All interactive
+elements, containers, and inputs utilize a minimal **4px corner radius**. This
+provides just enough softness to feel modern while maintaining a rigid,
+engineered aesthetic.
+```
+
+### Design Tokens
+
+The `rounded` section defines the design tokens for rounded corners used in
+buttons, cards, and other rectangular shapes.
+
+It is a map\<string, Dimension>.
+
+```yaml
+rounded:
+  sm: 4px
+  md: 8px
+  lg: 12px
+  full: 9999px
+```
+
+## Components
+
+This section provides style guidance for component atoms within the design system. The following are common component types. Design systems are encouraged to define additional components relevant to their domain.
+
+* **Buttons**: Covers primary, secondary, and tertiary variants, including sizing, padding, and states.
+* **Chips**: Covers selection chips, filter chips, and action chips.
+* **Lists**: Covers styling for list items, dividers, and leading/trailing elements.
+* **Tooltips**: Covers positioning, colors, and timing.
+* **Checkboxes**: Covers checked, unchecked, and indeterminate states.
+* **Radio buttons**: Covers selected and unselected states.
+* **Input fields**: Covers text inputs, text areas, labels, helper text, and error states.
+
+> **Note:** The components specification is actively evolving. The current structure provides intentional flexibility for domain-specific component definitions while the spec matures.
+
+### Design Tokens
+
+The components section defines a collection of design tokens used to ensure consistent styling of common components. It's a map\<string, map\<string, string>> that maps a component identifier to a group of sub token names and values. The design token values may be literal values, or references to previously defined design tokens.
+
+**Variants**. A component may have a variant for different UI states such as active, hover, pressed, etc. Those variant components may be defined under a different but related key, for example, "button-primary", "button-primary-hover", "button-primary-active". The agent will consider all variants and make the appropriate styling decisions.
+
+```yaml
+components:
+  button-primary:
+    backgroundColor: "{colors.primary-60}"
+    textColor: "{colors.primary-20}"
+    rounded: "{rounded.md}"
+    padding: 12px
+  button-primary-hover:
+    backgroundColor: "{colors.primary-70}"
+```
+
+### Component Property Tokens
+
+Each component has a set of properties that are themselves design tokens:
+
+- backgroundColor: \<Color\>
+- textColor: \<Color\>
+- typography: \<Typography\>
+- rounded: \<Dimension\>
+- padding: \<Dimension\>
+- size: \<Dimension\>
+- height: \<Dimension\>
+- width: \<Dimension\>
+
+## Do's and Don'ts
+
+This section provides practical guidelines and common pitfalls. These act as guardrails when creating designs.
+
+```markdown
+## Do's and Don'ts
+
+- Do use the primary color only for the single most important action per screen
+- Don't mix rounded and sharp corners in the same view
+- Do maintain WCAG AA contrast ratios (4.5:1 for normal text)
+- Don't use more than two font weights on a single screen
+```
+
+# Recommended Token Names (Non-Normative)
+
+The following names are commonly used across design systems. They are not required but are provided as guidance for consistency.
+
+**Colors:** `primary`, `secondary`, `tertiary`, `neutral`, `surface`, `on-surface`, `error`
+
+**Typography:** `headline-display`, `headline-lg`, `headline-md`, `body-lg`, `body-md`, `body-sm`, `label-lg`, `label-md`, `label-sm`
+
+**Rounded:** `none`, `sm`, `md`, `lg`, `xl`, `full`
+
+# Consumer Behavior for Unknown Content
+
+When a DESIGN.md consumer encounters content not defined by this spec:
+
+| Scenario | Behavior | Example |
+|---|---|---|
+| Unknown section heading | Preserve; do not error | `## Iconography` |
+| Unknown color token name | Accept if value is valid | `surface-container-high: '#ede7dd'` |
+| Unknown typography token name | Accept as valid typography | `telemetry-data` |
+| Unknown spacing value | Accept; store as string if not a valid dimension | `grid-columns: '5'` |
+| Unknown component property | Accept with warning | `borderColor` |
+| Duplicate section heading | Error; reject the file | Two `## Colors` headings |
+
+<!-- ===== END VENDORED UPSTREAM: docs/spec.md ===== -->

--- a/skills/superdesign/references/GRAPHIC.md
+++ b/skills/superdesign/references/GRAPHIC.md
@@ -4,6 +4,8 @@ Use this workflow when the user asks for a **static poster-like artwork** — po
 
 CLI setup and login live in `SKILL.md` (the "Superdesign CLI" and "When a command fails" sections) — follow those. From `SUPERDESIGN.md`, only these sections apply to graphics: the COMMAND CONTRACT, `upload-asset`, VERSION HISTORY & REVERT, the canvas-URL surfacing, TOOL USE RULE, and USER REQUEST PASSING. The init/design-system gates do NOT apply here: a standalone poster/marketing asset needs no repo init, no `.superdesign/init/` files, and no `design-system.md`/`globals.css` context — the brief carries the style. (Only run init and pass the design system if the user explicitly asks for on-brand output matching an existing codebase.)
 
+**On-brand exception:** graphics stay design-system-free by default, but when the user asks for output that matches an existing codebase's brand, the project's `DESIGN.md` (its normative token front matter — see `SUPERDESIGN.md` detection and consumption rules) is the preferred design-system context to attach.
+
 Core idea: **you** produce the key visual with your own image-generation tool, upload it to Superdesign, and let Superdesign compose the graphic as pixel-perfect HTML on a fixed canvas. Text is always rendered by the HTML layer, never baked into images — that is what keeps graphics sharp, editable, and iterable.
 
 A graphic lives in a project like any draft. Reuse the current project or `create-project --title "<topic> Graphics"` first.

--- a/skills/superdesign/references/INIT.md
+++ b/skills/superdesign/references/INIT.md
@@ -1,7 +1,7 @@
 You are performing a **Superdesign Init** — analyzing this repository to build UI context files that Superdesign agent will use for design tasks.
 
 ## Output Directory
-Write all files to `.superdesign/init/` in the project root.
+Write all context files to `.superdesign/init/` in the project root. The one exception is a generated `DESIGN.md`: when the project has NO `DESIGN.md` of its own, write it at the repo **root** (Case C in step 5) so other DESIGN.md-aware tooling can find it; only when the project already has an INVALID `DESIGN.md` do we keep ours inside `.superdesign/init/` (Case B). See step 5 for the full rule.
 
 ## Analysis Steps
 
@@ -54,16 +54,32 @@ Map out the page/route structure:
 
 For key pages (home, dashboard, main features), include a brief summary of what the page renders.
 
-### 5. Write `theme.md`
-Extract the design system / theme tokens. Structure the file in **two parts, in this order**:
+### 5. Provide the design tokens as `DESIGN.md` (+ `theme-raw.md` sidecar)
 
-**Part 1 — Compact token summary (at the TOP).** A concise, readable digest of the actual values: the color palette (token name → value, incl. `:root` and `.dark`), font families and type scale, spacing scale, border-radius, shadows, and breakpoints. This summary is the budget-friendly context the design flow reaches for first — the PAYLOAD BUDGET rule in `SUPERDESIGN.md` points here to avoid passing a giant `globals.css` whole. Keep it tight enough to pass as context on its own.
+Capture the design system / theme tokens in the interoperable **DESIGN.md** format (Google Labs' open format for design systems). DESIGN.md is the **visual-identity layer**: normative design tokens in YAML front matter plus prose rationale, readable by any DESIGN.md-aware tool. It replaces the old `theme.md`. The other init files (`components.md`, `layouts.md`, `routes.md`, `pages.md`, `extractable-components.md`) remain the **code-context layer** with full source and dependency trees — do NOT fold them into DESIGN.md.
 
-**Part 2 — Raw source dumps (BELOW the summary).** The complete raw files in fenced code blocks, for when the full source is needed:
+**Format authority:** follow `DESIGNMD-SPEC.md` in this `references/` directory (a pinned, verbatim snapshot of the upstream spec). Consult it locally; do NOT fetch the network or run any DESIGN.md CLI. Key rule from the spec: *the tokens are the normative values; the prose provides context for how to apply them.*
+
+**Detection (in this order): project root `DESIGN.md`, then `docs/DESIGN.md`.** Then branch:
+
+- **Case A — a project `DESIGN.md` exists and is valid per the spec** (front matter parses; no duplicate `##` section headings — a duplicate section heading is the one hard invalidity in the spec's "Consumer Behavior for Unknown Content" table): consume it **READ-ONLY** as the theme/token context. **NEVER overwrite or edit a pre-existing project `DESIGN.md`** — it may be hand-written or another tool's asset. Do NOT regenerate; the project's own valid file already satisfies the DESIGN.md slot.
+- **Case B — a project `DESIGN.md` exists but is INVALID per the spec** (e.g. a duplicate section heading, which the spec says rejects the file): leave the file **UNTOUCHED**, note the specific problem to the user, and generate our own spec-compliant version at `.superdesign/init/DESIGN.md` (the context output dir — NOT the repo root, so we never shadow or fight the project's file).
+- **Case C — no project `DESIGN.md` anywhere** (neither root nor `docs/`): generate a spec-compliant `DESIGN.md` at the repo **ROOT**, extracted from the project's actual code (tokens from `globals.css`/`index.css`, `tailwind.config`, CSS variable definitions, theme provider/token files). Tell the user we created it and that a root `DESIGN.md` benefits any other DESIGN.md-aware agent tooling too, not just Superdesign.
+
+**Writing a spec-compliant `DESIGN.md` (Cases B and C only).** Follow `DESIGNMD-SPEC.md`. In brief:
+
+- **YAML front matter = normative tokens.** Populate `name`, `colors`, `typography`, `spacing`, `rounded`, and `components` from the values extracted from the code — the actual palette entries (incl. `:root` and `.dark`), font families and type scale, spacing scale, and border-radii. Use `{path.to.token}` references (e.g. `{colors.primary}`) inside `components` where a value reuses another token.
+- **Markdown body = rationale**, in the spec's canonical section order: **Overview, Colors, Typography, Layout, Elevation & Depth, Shapes, Components, Do's and Don'ts.** Omit a section only if genuinely irrelevant; keep the sections you include in that order; NEVER emit a duplicate `##` section heading (that makes the file invalid).
+
+**Components section ← `extractable-components.md` (linkage).** When generating DESIGN.md, summarize each extractable component's visual properties (background/text colors, padding, border-radius — as `{token.references}` where possible) into the `components` token group in the front matter. In the Components **prose** section, point back to our code-context files (`components.md`, `layouts.md`, `extractable-components.md`) for the full source — DESIGN.md carries visual identity, not implementation.
+
+**Always also write `theme-raw.md`** to `.superdesign/init/` — the raw source dumps, kept OUT of DESIGN.md so the spec file stays clean. Pass this sidecar as context only when exact style reproduction is needed:
 - Full `tailwind.config.ts/js` content (especially `theme.extend`)
 - Full `globals.css` / `index.css` content
 - Full CSS variable definitions (`:root`, `[data-theme]`, etc.)
 - Any theme provider files and design token files
+
+**This step's slot is satisfied when:** a valid `DESIGN.md` is available (the project's own valid one, or the one we generated) AND `.superdesign/init/theme-raw.md` exists. A pre-existing valid project `DESIGN.md` satisfies the slot without regeneration.
 
 ### 6. Write `pages.md`
 For each key page/route in the app (home, dashboard, main features — up to 10 pages), build a **complete component dependency tree** by tracing imports recursively.
@@ -146,7 +162,7 @@ This file serves as a "menu" — the design workflow reads it to decide which co
 - Include file paths as code spans
 - **For `components.md`**: include FULL source code of each component in fenced code blocks
 - **For `layouts.md`**: include FULL file contents in fenced code blocks
-- **For `theme.md`**: include raw token values, CSS variables, and Tailwind config — not just descriptions
+- **For `DESIGN.md`**: normative tokens in YAML front matter + prose rationale in the spec's canonical section order (see `DESIGNMD-SPEC.md`); never a duplicate `##` heading. **For `theme-raw.md`**: include raw token values, CSS variables, and Tailwind config — not just descriptions
 - **For `pages.md`**: include complete dependency trees with indentation showing nesting depth
 - **For `extractable-components.md`**: include component name, source path, category, description, and key props — NOT full source code (that's in `components.md` and `layouts.md`)
 - Keep descriptions concise — the goal is machine-readable context, not documentation

--- a/skills/superdesign/references/SUPERDESIGN.md
+++ b/skills/superdesign/references/SUPERDESIGN.md
@@ -2,7 +2,7 @@ You are "Superdesign Agent". Your job is to use Superdesign to generate and iter
 
 IMPORTANT: MUST produce design on superdesign, only implement actual code AFTER user approve OR the user explicitly says 'skip design and implement'
 
-⛔ HARD GATE — INIT BEFORE ANY DESIGN (real-codebase path only): When a real codebase is present, NEVER run `npx --yes @superdesign/cli@latest create-project`, `npx --yes @superdesign/cli@latest create-design-draft`, `npx --yes @superdesign/cli@latest iterate-design-draft`, or `npx --yes @superdesign/cli@latest execute-flow-pages` until init is complete (all six files in `.superdesign/init/` exist and are non-empty — the decidable test in Task 1.1). If init is missing, incomplete, or still running, WAIT for it to finish first. Creating a project or draft before init is done is a hard error. This gate does NOT apply to:
+⛔ HARD GATE — INIT BEFORE ANY DESIGN (real-codebase path only): When a real codebase is present, NEVER run `npx --yes @superdesign/cli@latest create-project`, `npx --yes @superdesign/cli@latest create-design-draft`, `npx --yes @superdesign/cli@latest iterate-design-draft`, or `npx --yes @superdesign/cli@latest execute-flow-pages` until init is complete (all six init slots satisfied and non-empty — the decidable test in Task 1.1). If init is missing, incomplete, or still running, WAIT for it to finish first. Creating a project or draft before init is done is a hard error. This gate does NOT apply to:
 
 - **the no-codebase path** (empty/scratch/sandbox workspace with no frontend code — see SKILL.md Step 1): there is nothing to init, so gather design context conversationally and design directly via **SOP: BRAND NEW PROJECT** below.
 - **the graphic workflow** (`references/GRAPHIC.md`): posters/marketing assets are standalone fixed-canvas artworks that never require repo init or design-system context — UNLESS the user explicitly asks for on-brand output that matches the codebase, in which case run init first and pass the design system as usual.
@@ -15,18 +15,34 @@ Collect the two workstreams below in parallel when the current agent environment
 Task 1.1 - UI Source Context:
 Superdesign agent has no context of our codebase and current UI, so first step is to identify and read the most relevant source files to pass as context.
 
-**MANDATORY FIRST STEP — the decidable init-complete test**: Init is complete only if ALL SIX named files exist AND are non-empty: `components.md`, `layouts.md`, `routes.md`, `theme.md`, `pages.md`, `extractable-components.md`. A directory that is missing any of them, or holds an empty one (e.g. an interrupted init), is NOT complete.
+**MANDATORY FIRST STEP — the decidable init-complete test**: Init is complete only if ALL SIX slots below are satisfied, each non-empty:
 
-- **If init is not complete** (any of the six missing or empty): You MUST run the full init analysis FIRST before any design work. Follow the INIT instructions from the skill to scan the repo and write all six files to `.superdesign/init/`. Re-running init regenerates all six files; overwriting existing ones is expected and fine. Do NOT proceed to Step 2 until init is complete.
-- **If init is complete**: Read ALL six files in this directory:
+1. `.superdesign/init/components.md`
+2. `.superdesign/init/layouts.md`
+3. `.superdesign/init/routes.md`
+4. **DESIGN.md slot** — a valid `DESIGN.md` is available (the project's own valid one, found by detection order **repo root `DESIGN.md`, then `docs/DESIGN.md`**; OR the one init generated — at the repo root when the project had none, or at `.superdesign/init/DESIGN.md` when the project's own was invalid) **AND** `.superdesign/init/theme-raw.md` exists. A pre-existing valid project `DESIGN.md` satisfies this slot without regeneration.
+5. `.superdesign/init/pages.md`
+6. `.superdesign/init/extractable-components.md`
+
+A slot that is missing, or a file that is empty (e.g. an interrupted init), is NOT complete.
+
+- **If init is not complete** (any slot unsatisfied or empty): You MUST run the full init analysis FIRST before any design work. Follow the INIT instructions from the skill to scan the repo and satisfy all six slots. Re-running init regenerates our own files; overwriting existing ones is expected and fine — EXCEPT a pre-existing valid project `DESIGN.md`, which init consumes read-only and NEVER overwrites. Do NOT proceed to Step 2 until init is complete.
+- **If init is complete**: Read ALL six init inputs:
   - components.md - shared UI primitives inventory
   - layouts.md - full source code of layout components
   - routes.md - route/page mapping
-  - theme.md - design tokens, CSS variables, Tailwind config
+  - DESIGN.md - normative design tokens (YAML front matter) + design rationale prose (detection order: repo root, then `docs/`, then `.superdesign/init/`); its sidecar `theme-raw.md` holds the raw CSS/Tailwind dumps
   - pages.md - page component dependency trees
   - extractable-components.md - reusable component candidates with source paths and props
 
 These files are pre-analyzed context and MUST be read every time before any design task.
+
+**Reading DESIGN.md (consumption rules — see `references/DESIGNMD-SPEC.md` for the format):**
+
+- **Tokens are normative; prose is context.** The YAML front matter carries all normative values; the prose sections explain how to apply them.
+- **Under PAYLOAD BUDGET pressure, pass only the YAML front matter** — it is officially sufficient because it carries all normative values. Include the prose sections only when the budget allows or the task needs the rationale. Pair DESIGN.md with `theme-raw.md` only when exact style reproduction needs the raw CSS/Tailwind source.
+- **Resolve `{path.to.token}` cross-references** when reading token values (e.g. a component's `backgroundColor: "{colors.primary}"` means the value of `colors.primary`).
+- **Tolerance per spec:** unknown section headings and unknown token names are fine — preserve/accept them. A **duplicate section heading makes the file invalid** — fall back exactly as INIT.md step 5 Case B does (leave the project file untouched, use our generated `.superdesign/init/DESIGN.md` instead).
 
 **READ THE REAL RENDER BRANCH (do not infer layout from an import name).** Before describing a page's layout in a reproduction prompt, open the page and read the branch that actually renders on the target route — components frequently branch by responsive state (`if (!isMobile) { return … }`), feature flag, or route. Pass the branch that renders (e.g. the desktop master-detail split), NOT a fallback (e.g. the mobile grid). NEVER pass a line range you have not read — a wrong branch is the #1 fidelity failure.
 
@@ -75,7 +91,7 @@ The design API rejects oversized context with a **400**. When that happens and t
 1. **Budget BEFORE the call.** Sum the lines of your `--context-file` set. A big page often pulls in a ~900+ line shared header + the ~900+ line page + a ~900+ line `globals.css` — that combination WILL 400. Apply the canonical ~900-line threshold (see **CONTEXT FILE LINE RANGES**) and keep the set lean:
    - **Shared shell/header/nav (~900+ lines): line-range to its render section only** (e.g. the `<header>` JSX `:452:1247`, not the 1249-line whole file). Skip the hooks/handlers/menus above the render.
    - **The target page (~900+ lines): line-range to the render branch that actually renders** (e.g. the desktop `!isMobile` block `:697:935`), not the whole multi-branch file.
-   - **`globals.css` (~900+ lines): do NOT pass it whole.** Prefer the compact token summary at the top of `.superdesign/init/theme.md` for the values; or line-range globals to its `:root`/`.dark` token block only.
+   - **`globals.css` (~900+ lines): do NOT pass it whole.** Prefer the normative token values in the `DESIGN.md` YAML front matter; or line-range globals to its `:root`/`.dark` token block only. Reach for the `theme-raw.md` sidecar only when exact style reproduction needs the raw CSS.
 2. **On a 400: trim the BIG files to their render sections and retry the SAME faithful call.** NEVER retry with a thinned/minimal context just to make the call succeed — a reproduction off thin context is invention, not reproduction. If you cannot fit the real page, STOP and tell the user; do not ship an invented draft.
 3. **Prefer a self-contained page when the user is flexible.** A page that is one big UI component (no giant shared-shell dependency) reproduces faithfully and fits the budget; a shell-dependent page requires the line-ranging above. (A self-contained `/detail` page reproduced cleanly where a shell-dependent `/list` page 400'd — same model, only the payload differed.)
 
@@ -277,7 +293,7 @@ Without explicit constraints, the Superdesign design agent will invent random fo
 To prevent this:
 
 1. **ALWAYS pass `--context-file .superdesign/design-system.md`** on EVERY iterate-design-draft and create-design-draft call
-2. **ALWAYS pass the globals.css tokens** on EVERY call — this contains the actual CSS tokens. Pass the file whole when it is under ~900 lines; at ~900+ lines pass its `:root`/`.dark` token block (line-ranged) or the token summary from `.superdesign/init/theme.md` instead (see the canonical rule in CONTEXT FILE LINE RANGES / PAYLOAD BUDGET)
+2. **ALWAYS pass the design tokens** on EVERY call — the actual token values. Pass the `DESIGN.md` YAML front matter (officially sufficient — it carries all normative values); or pass `globals.css` whole when it is under ~900 lines; at ~900+ lines pass its `:root`/`.dark` token block (line-ranged) instead (see the canonical rule in CONTEXT FILE LINE RANGES / PAYLOAD BUDGET)
 3. **ALWAYS append the fidelity constraint** to every -p prompt (see above)
 4. **Be explicit about what MUST stay the same** — e.g. "keep Inter as the font family, use black/white primary palette, amber/orange brand gradients only"
 
@@ -353,10 +369,10 @@ Every draft keeps a version history. The CLI's default output already self-discl
 
 - Design system file path is fixed: .superdesign/design-system.md
 - design-system.md = ALL design specs
-- **MANDATORY INIT (real-codebase path)**: When a real codebase is present, if init is not complete (any of the six files — components.md, layouts.md, routes.md, theme.md, pages.md, extractable-components.md — missing or empty, per the decidable test in Task 1.1) you MUST run the full init analysis FIRST (follow the INIT instructions from the skill); if it is complete, you MUST read ALL six files at the START of every design task. This is NOT optional. Two exemptions: on the no-codebase path (empty/scratch/sandbox workspace, no frontend code — see SKILL.md Step 1) there is nothing to init, so skip it and gather design context conversationally; and the graphic workflow (`references/GRAPHIC.md`) needs no init for standalone posters/marketing assets unless the user explicitly asks for on-brand output matching the codebase.
+- **MANDATORY INIT (real-codebase path)**: When a real codebase is present, if init is not complete (any of the six slots — components.md, layouts.md, routes.md, the DESIGN.md slot (a valid DESIGN.md available + theme-raw.md), pages.md, extractable-components.md — unsatisfied or empty, per the decidable test in Task 1.1) you MUST run the full init analysis FIRST (follow the INIT instructions from the skill); if it is complete, you MUST read ALL six init inputs at the START of every design task. This is NOT optional. Two exemptions: on the no-codebase path (empty/scratch/sandbox workspace, no frontend code — see SKILL.md Step 1) there is nothing to init, so skip it and gather design context conversationally; and the graphic workflow (`references/GRAPHIC.md`) needs no init for standalone posters/marketing assets unless the user explicitly asks for on-brand output matching the codebase.
 - **MANDATORY CONTEXT FILES on EVERY design command** (create-design-draft, iterate-design-draft, execute-flow-pages):
   - Always pass `--context-file .superdesign/design-system.md` so the design agent knows the allowed fonts, colors, and spacing.
-  - On the real-codebase path, also pass the globals.css tokens (whole under ~900 lines, else its `:root`/`.dark` block or theme.md token summary — see PAYLOAD BUDGET) when that file exists so the design agent has the actual CSS tokens and variables.
+  - On the real-codebase path, also pass the design tokens (the `DESIGN.md` YAML front matter, which is officially sufficient; or `globals.css` whole under ~900 lines, else its `:root`/`.dark` block — see PAYLOAD BUDGET) so the design agent has the actual tokens and variables.
   - On the no-codebase path, `globals.css` is not required; do not invent one solely to satisfy this rule.
   - **Graphic-workflow exemption**: standalone posters/marketing assets (`references/GRAPHIC.md`) require NO `design-system.md` or `globals.css` context — the brief carries the style. Only pass the design system when the user explicitly asks for on-brand output matching the codebase.
 - **DESIGN SYSTEM = HARD CONSTRAINT, NOT SUGGESTION**: Iteration prompts explore layout/structure/content direction, NOT visual style. The design system defines the visual style. Never let a -p prompt override the design system.
@@ -397,7 +413,7 @@ Multiple ranges from the same file are automatically merged into a single contex
 | --- | --- |
 | **Under ~900 lines** | FULL file. NEVER trim CSS, JSX/template, config, or any other visual code. The only line-ranging allowed here is skipping a large pure-logic block (data fetching / hooks / handlers) — e.g. `src/pages/Dashboard.tsx:60` keeps all JSX from line 60. |
 | **~900 lines or more (MANDATORY)** | Line-range to the sections that matter — this is the ONLY sanctioned way to "trim visual code". For a page/component: the render branch that actually renders. For CSS: the used selectors + the `:root`/`.dark` token block (e.g. `globals.css:1:120` for variables + `globals.css:800:900` for used component styles). For config: the relevant block. |
-| **`globals.css` ~900+ lines** | Do NOT pass whole. Prefer the compact token summary at the top of `.superdesign/init/theme.md`, or line-range globals to its `:root`/`.dark` token block only. |
+| **`globals.css` ~900+ lines** | Do NOT pass whole. Prefer the normative token values in the `DESIGN.md` YAML front matter, or line-range globals to its `:root`/`.dark` token block only. |
 
 Files that are always FULL when under ~900 lines: ALL UI components (Button, Card, Nav, Sidebar, etc.), ALL layout files, and any file where UI and logic are interleaved (safer to include everything).
 


### PR DESCRIPTION
## Summary

Adopt Google Labs' [DESIGN.md](https://github.com/google-labs-code/design.md) format in the Superdesign skill. The skill now reads a project's existing `DESIGN.md` as design-system/token context and writes a spec-compliant one during init, replacing `theme.md`'s role.

**Layering:** DESIGN.md is the visual-identity layer (standardized, interoperable tokens + rationale); `components/layouts/routes/pages/extractable-components.md` remain the code-context layer (full source, dependency trees). They are not merged.

## Changes

- **Vendored spec** — `references/DESIGNMD-SPEC.md`: verbatim snapshot of upstream `docs/spec.md` (commit `bde692f`, version `alpha`) with an Apache-2.0 attribution header (upstream URL, commit, fetch date, version). Pinned local reference; no runtime dependency on any DESIGN.md CLI.
- **INIT.md** — step 5 replaces the `theme.md` step with a DESIGN.md read/write step:
  - Detection order: repo root `DESIGN.md`, then `docs/DESIGN.md`.
  - **Valid project DESIGN.md** → consume READ-ONLY, never overwrite.
  - **Invalid** (duplicate `##` headings per spec) → leave untouched, note to user, generate our own at `.superdesign/init/DESIGN.md`.
  - **Absent** → generate a spec-compliant `DESIGN.md` at repo root from the actual code.
  - Raw CSS/Tailwind dumps move to a `theme-raw.md` sidecar (kept out of DESIGN.md).
  - `extractable-components.md` linkage: visual props summarized into the `components` token group; prose points back to code-context files.
- **SUPERDESIGN.md** — DESIGN.md consumption rules (tokens normative; front matter alone is sufficient under PAYLOAD BUDGET pressure; resolve `{path.to.token}` refs; spec tolerance + duplicate-heading fallback). Updated the init-complete predicate, HARD GATE, PAYLOAD BUDGET, MANDATORY CONTEXT FILES, and trimming rules coherently.
- **SKILL.md** — minimal pointer edits to the init-flow summary.
- **GRAPHIC.md** — one clause: DESIGN.md is the preferred on-brand design-system context.
- **AGENTS.md** — record the DESIGN.md tokens-layer knowledge.

## Verification

- `grep -rn "theme.md"` returns only one intentional historical mention ("replaces the old theme.md").
- Vendored spec body diffs byte-identical against upstream.
- SKILL → INIT → SUPERDESIGN read as one consistent story for all three cases (project has valid / invalid / absent DESIGN.md).

_Note: no plugin.json / version metadata touched - left for release review._