### PR TITLE
chore(plugin): bump to 0.4.1, rename marketplace display name to "01 Superdesign"

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "superdesign",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Superdesign adds a design skill to ChatGPT that spans both web UI and graphics.",
   "author": {
     "name": "Superdesign dev, Inc.",
@@ -12,13 +12,24 @@
   "license": "MIT",
   "keywords": [
     "design",
-    "frontend",
-    "ui",
-    "ux"
+    "ui-design",
+    "web-design",
+    "landing-pages",
+    "dashboards",
+    "wireframes",
+    "mockups",
+    "prototyping",
+    "design-systems",
+    "branding",
+    "graphics",
+    "posters",
+    "image-generation",
+    "infinite-canvas",
+    "design-drafts"
   ],
   "skills": "./skills/",
   "interface": {
-    "displayName": "Superdesign",
+    "displayName": "01 Superdesign",
     "shortDescription": "Create polished UI & graphics",
     "longDescription": "From landing pages to launch graphics, Superdesign turns your ideas into polished visuals you can explore and refine with ChatGPT. See multiple directions side by side on an infinite browser canvas, choose what feels right, and keep iterating—all grounded in your brand and existing design system.",
     "developerName": "Superdesign",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,10 @@ The skill invokes `npx --yes @superdesign/cli@latest`. When editing any command 
 - Valid `--model` values: run `list-models` (or pass a bogus `--model` to any generation command; the validation error prints the same list)
 - Default (no `--json`) output is agent-optimized (compact TOON + `help[]` hints); add `--json` only for the full machine payload, `--full` only to expand truncated fields
 
+## Plugin packaging & release
+
+The Codex-plugin manifest is `.codex-plugin/plugin.json`. Releasing a new version is a single `chore(plugin): bump to X.Y.Z` commit editing its `version`, merged via PR - there are **no git tags, no GitHub releases, and no CI/publish workflow** (verify with `git tag` / `gh release list` before assuming otherwise). The marketplace-facing **display name** lives in two files that must stay in sync: `.codex-plugin/plugin.json` `interface.displayName` and `skills/superdesign/agents/openai.yaml` `display_name`. These are distinct from machine identity - the plugin slug (`plugin.json` `name`), the skill dir/`SKILL.md` `name`, and the `$superdesign` invocation - which must never change on a rename.
+
 ## Maintaining this file
 
 Keep this file for knowledge useful to almost every future agent session in this project.

--- a/skills/superdesign/agents/openai.yaml
+++ b/skills/superdesign/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Superdesign"
+  display_name: "01 Superdesign"
   short_description: "Create polished UI & graphics"
   default_prompt: "Use $superdesign to design an on-brand landing page for this product."


### PR DESCRIPTION
## What & why

Rename the **marketplace-facing display name** so the store listing sorts to the top of the general tier (directory listings sort alphabetically within a tier; digits sort before letters). Final captain-chosen name, exactly: **`01 Superdesign`**. Also expands marketplace **keywords** for discovery and bumps the plugin version.

> ✅ **Store publish already done.** The captain has already published the built `0.4.1` artifact to the store from this branch's committed state. This PR lands the same change in the repo.

## Display surfaces changed (rename only)

- `.codex-plugin/plugin.json` → `interface.displayName`: `Superdesign` → `01 Superdesign`
- `skills/superdesign/agents/openai.yaml` → `display_name`: `Superdesign` → `01 Superdesign`

There is no `marketplace.json` in this repo; the `interface` block in `plugin.json` is the marketplace listing.

## Keywords (top-level `keywords` array)

Replaced `["design","frontend","ui","ux"]` with:

```
["design","ui-design","web-design","landing-pages","dashboards","wireframes","mockups","prototyping","design-systems","branding","graphics","posters","image-generation","infinite-canvas","design-drafts"]
```

## Version bump

- `.codex-plugin/plugin.json` `version`: `0.4.0` → `0.4.1`, following the repo's own convention — a `chore(plugin): bump to X.Y.Z` commit. There are no git tags, GitHub releases, or CI/publish workflow in this repo, so there is no tag to push.

## Machine identity — deliberately unchanged (HARD RULE)

Plugin slug (`plugin.json` `name`), skill dir + `SKILL.md` front-matter `name`, the `$superdesign` invocation, `interface.developerName`, and `author.name` all stay `superdesign`. Existing installs and `skills add` / plugin-add commands keep working unchanged. Brand prose in `README.md` / `INSTALL.md` intentionally stays "Superdesign".

## Docs

Added a **Plugin packaging & release** note to `AGENTS.md` documenting the display-name surfaces and the tagless version-bump release convention.

## Validation

- `plugin.json` re-parsed as valid JSON; `openai.yaml` re-parsed as valid YAML — both verified from inside the packaged zip.
- Packaged artifact `UPLOAD-THIS-superdesign-plugin-0.4.1.zip` built to match the prior `0.4.0` release layout exactly (entry-name parity confirmed via `diff`); install-resolution smoke test passes.
- No CI/validation scripts exist to run.
