### PR TITLE
feat(plugin): package as a Claude Code plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
+  "name": "superdesign",
+  "description": "The Superdesign design skill for Claude Code, published by Superdesign dev, Inc.",
+  "owner": {
+    "name": "Superdesign dev, Inc.",
+    "email": "support@superdesign.dev",
+    "url": "https://superdesign.dev"
+  },
+  "plugins": [
+    {
+      "name": "superdesign",
+      "source": "./",
+      "category": "design",
+      "tags": [
+        "design",
+        "ui",
+        "design-systems",
+        "graphics"
+      ]
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "superdesign",
+  "displayName": "Superdesign",
+  "version": "0.4.1",
+  "description": "Design or redesign frontend UI and marketing graphics on the Superdesign infinite canvas. Reads your codebase for context, sets up a design system, and generates branchable design drafts you refine.",
+  "author": {
+    "name": "Superdesign dev, Inc.",
+    "email": "support@superdesign.dev",
+    "url": "https://superdesign.dev"
+  },
+  "homepage": "https://superdesign.dev",
+  "repository": "https://github.com/superdesigndev/superdesign-skill",
+  "license": "MIT",
+  "keywords": [
+    "design",
+    "ui-design",
+    "web-design",
+    "landing-pages",
+    "dashboards",
+    "wireframes",
+    "mockups",
+    "prototyping",
+    "design-systems",
+    "branding",
+    "graphics",
+    "posters",
+    "image-generation",
+    "infinite-canvas",
+    "design-drafts"
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,11 @@ The skill invokes `npx --yes @superdesign/cli@latest`. When editing any command 
 
 ## Plugin packaging & release
 
-The Codex-plugin manifest is `.codex-plugin/plugin.json`. Releasing a new version is a single `chore(plugin): bump to X.Y.Z` commit editing its `version`, merged via PR - there are **no git tags, no GitHub releases, and no CI/publish workflow** (verify with `git tag` / `gh release list` before assuming otherwise). The marketplace-facing **display name** lives in two files that must stay in sync: `.codex-plugin/plugin.json` `interface.displayName` and `skills/superdesign/agents/openai.yaml` `display_name`. These are distinct from machine identity - the plugin slug (`plugin.json` `name`), the skill dir/`SKILL.md` `name`, and the `$superdesign` invocation - which must never change on a rename.
+The repo root doubles as **two** plugins off one `skills/superdesign/` tree: `.codex-plugin/plugin.json` (Codex) and `.claude-plugin/plugin.json` (Claude Code, alongside a self-hosted `.claude-plugin/marketplace.json` that lists the repo root as `"source": "./"`). Releasing a new version is a single `chore(plugin): bump to X.Y.Z` commit editing the `version` in **both** manifests plus the `## Unreleased` heading in `CHANGELOG.md`, merged via PR - there are **no git tags, no GitHub releases, and no CI/publish workflow** (verify with `git tag` / `gh release list` before assuming otherwise). Both marketplaces treat an explicit `version` as the update cache key, so pushing commits without bumping ships nothing to users.
+
+Validate any manifest edit with `claude plugin validate ./.claude-plugin/plugin.json --strict` and `claude plugin validate ./.claude-plugin/marketplace.json --strict` (the bare `claude plugin validate .` resolves to the marketplace file, not the plugin one). The Claude Code review pipeline runs the same check on submission.
+
+The marketplace-facing **display name** lives in three files. The two ChatGPT-facing ones must stay in sync with each other - `.codex-plugin/plugin.json` `interface.displayName` and `skills/superdesign/agents/openai.yaml` `display_name` - and carry the `01 ` listing-sort prefix. `.claude-plugin/plugin.json` `displayName` deliberately drops that prefix, since Claude Code's `/plugin` picker does not sort by name. All three are distinct from machine identity - the plugin slug (both `plugin.json` `name` fields), the skill dir/`SKILL.md` `name`, and the `$superdesign` / `superdesign:superdesign` invocations - which must never change on a rename.
 
 ## Maintaining this file
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+Notable changes to the Superdesign skill and its plugin packaging.
+
+Both plugin manifests carry an explicit `version`, so marketplaces only hand users an update when that
+field is bumped — every release entry below corresponds to a `chore(plugin): bump to X.Y.Z` commit that
+bumps `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` together.
+
+## Unreleased
+
+- Package the repo as a Claude Code plugin: `.claude-plugin/plugin.json` manifest, plus a self-hosted
+  `.claude-plugin/marketplace.json` so it installs with
+  `/plugin marketplace add superdesigndev/superdesign-skill` +
+  `/plugin install superdesign@superdesign`.
+- Preflight: the ChatGPT-specific "switch to the Work tab" message is now scoped to ChatGPT chat. Other
+  harnesses that cannot run shell commands get a harness-neutral message instead.
+- README and INSTALL.md document the Claude Code plugin install path alongside `npx skills add`.
+
+## 0.4.1 and earlier
+
+Not tracked here. See the git history (`git log --grep "bump to"`) for prior releases.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,7 +14,22 @@ propose design ideas, and do NOT run things in parallel — just init, then ask 
 
 ## Step 1 — Install the Superdesign skill into yourself
 
-Run (non-interactive), substituting **your own agent's slug**:
+**Already installed?** If you are reading this because the Superdesign skill or plugin is already loaded in
+this session (you can invoke `superdesign` / `superdesign:superdesign`), skip straight to Step 2 — do not
+install a second copy.
+
+**Claude Code** — install the plugin instead of the skill, and tell the user to run these two, since `/plugin`
+is a user-typed command you cannot run for them:
+
+```
+/plugin marketplace add superdesigndev/superdesign-skill
+/plugin install superdesign@superdesign
+```
+
+Then continue at Step 2. Do NOT also run `npx skills add` — that leaves a second, unnamespaced copy of the
+same skill.
+
+**Every other agent** — run (non-interactive), substituting **your own agent's slug**:
 
 ```
 npx skills add superdesigndev/superdesign-skill -g -a <your-agent-slug> -y

--- a/README.md
+++ b/README.md
@@ -27,11 +27,22 @@ Install it once and your agent (Claude Code, Cursor, Codex, and 70+ others) can 
 
 ## Install
 
+**Any coding agent** — installs the skill for any of the [70+ supported coding agents](https://github.com/vercel-labs/skills#supported-agents):
+
 ```
 npx skills add superdesigndev/superdesign-skill
 ```
 
-This works for any of the [70+ supported coding agents](https://github.com/vercel-labs/skills#supported-agents). Then install the CLI it drives:
+**Claude Code** — install it as a plugin instead, so it stays namespaced and updates with `/plugin update`:
+
+```
+/plugin marketplace add superdesigndev/superdesign-skill
+/plugin install superdesign@superdesign
+```
+
+The skill is then invoked as `/superdesign:superdesign`. (Do not also run `npx skills add` in Claude Code — that installs a second, unnamespaced copy of the same skill.)
+
+Either way, install the CLI it drives:
 
 ```
 npm install -g @superdesign/cli@latest

--- a/skills/superdesign/SKILL.md
+++ b/skills/superdesign/SKILL.md
@@ -20,13 +20,15 @@ Superdesign helps you (1) find design inspirations/styles and (2) generate/itera
 
 Superdesign runs entirely through its CLI, so you must be able to execute shell commands. Confirm that capability first, before any CLI verification.
 
-If Superdesign is invoked in standard ChatGPT chat without Work Mode tools, do not start the workflow. Tell the user once:
+If you have no way to run shell commands in this environment (no terminal/execution tool at all), OR your very first bare `npx --yes @superdesign/cli@latest` preflight attempt fails because command execution itself is unavailable (the harness reports it cannot run commands / there is no shell) then STOP. Do NOT keep retrying or improvise workarounds. Tell the user once, and pick the message that matches where you are running:
 
-```text
-Chat isn't supported by the Superdesign plugin. Please switch to the Work tab and paste this prompt in for the full experience.
-```
+- **Standard ChatGPT chat without Work Mode tools** — this exact copy, because the Work tab is the fix:
 
-If you have no way to run shell commands in this environment (no terminal/execution tool at all), OR your very first bare `npx --yes @superdesign/cli@latest` preflight attempt fails because command execution itself is unavailable (the harness reports it cannot run commands / there is no shell) then STOP. Do NOT keep retrying or improvise workarounds.
+  ```text
+  Chat isn't supported by the Superdesign plugin. Please switch to the Work tab and paste this prompt in for the full experience.
+  ```
+
+- **Any other harness** (a coding agent whose shell is unavailable or disabled) — do NOT send the ChatGPT copy; there is no Work tab to switch to. Say plainly that Superdesign drives its CLI over the shell, that this session cannot run shell commands, and that they can re-run it in a session with shell access or design in the web app at https://superdesign.dev.
 
 # Step 1 — Is there a codebase to analyze?
 


### PR DESCRIPTION
Makes this repo installable as a Claude Code plugin and ready to submit to the community marketplace, without touching how it ships to Codex or to the 70+ agents served by `npx skills add`.

## Why

`claude plugin validate .` currently fails outright:

```
✘ directory: No manifest found in directory. Expected .claude-plugin/marketplace.json or .claude-plugin/plugin.json
```

That check is exactly what the community-marketplace review pipeline runs on submission. Everything else about the layout already matches the plugin spec - `skills/superdesign/SKILL.md` plus `references/` at the plugin root is the standard structure, so no skill files move.

## What changed

- **`.claude-plugin/plugin.json`** - the required manifest. `skills/` is a default scan path, so no component-path fields are needed. Version starts at `0.4.1` to match the current release rather than sneaking a bump into a feature PR.
- **`.claude-plugin/marketplace.json`** - self-hosted marketplace listing the repo root (`"source": "./"`), so users can install today, independent of the review queue:

  ```
  /plugin marketplace add superdesigndev/superdesign-skill
  /plugin install superdesign@superdesign
  ```

- **README / INSTALL.md** - document the plugin path alongside `npx skills add`, and warn against installing both (that leaves a second, unnamespaced copy of the same skill). INSTALL.md also gains an "already installed, skip to Step 2" guard, since a plugin user reading it would otherwise self-install a duplicate.
- **SKILL.md Step 0** - the ChatGPT-specific "switch to the Work tab" copy is now scoped to ChatGPT chat. Any other harness that cannot run shell commands gets a harness-neutral message, instead of telling a Claude Code user to find a Work tab that does not exist.
- **CHANGELOG.md** and **AGENTS.md** - the release convention now covers two manifests whose `version` must be bumped together, since both marketplaces use an explicit `version` as the update cache key.

`.codex-plugin/plugin.json` is untouched. The two manifests are separate files, so there is no conflict; the only intentional divergence is `displayName`, which drops the `01 ` listing-sort prefix that only ChatGPT's directory needs.

## Verification

- `claude plugin validate ./.claude-plugin/plugin.json --strict` → passes
- `claude plugin validate ./.claude-plugin/marketplace.json --strict` → passes
- `claude --plugin-dir <repo>` → skill loads as `superdesign:superdesign`
- `superdesign` is not taken in the 2298-entry `anthropics/claude-plugins-community` catalog

## Follow-up (not in this PR)

Submitting to the community marketplace is a form, not a commit: [platform.claude.com/plugins/submit](https://platform.claude.com/plugins/submit) for individual authors, or claude.ai directory submissions for a Team/Enterprise org. Approved plugins get pinned by commit SHA in the community catalog, with CI bumping the pin as we push.

Note that the CLI-side plugin hint protocol (`<claude-code-hint />`) does not apply here - it only fires for plugins in the official `claude-plugins-official` marketplace, which is curated by Anthropic with no application process.