### PR TITLE
Add design-with-your-model fallback path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ A published agent **skill** (`skills/superdesign/`) that drives the SuperDesign 
 - `skills/superdesign/references/GRAPHIC.md` - poster/marketing-asset workflow (loaded only for graphics)
 - `skills/superdesign/references/WEBSITE.md` - live-site extraction recipes (loaded only for reference-URL tasks)
 - `skills/superdesign/references/COMPONENTS.md` - Petite-Vue template spec (loaded only before create/update-component conversions)
+- `skills/superdesign/references/design-with-your-model.md` - caller-model HTML authoring/import path (loaded only when explicitly requested or after create/iterate retry failure)
 - `skills/superdesign/{SUPERDESIGN,INIT}.md` - deprecated compatibility forwarders (do not add content)
 
 ## Skill flow invariant: two entry paths

--- a/skills/superdesign/SKILL.md
+++ b/skills/superdesign/SKILL.md
@@ -15,6 +15,7 @@ Superdesign helps you (1) find design inspirations/styles and (2) generate/itera
 4. **Help me improve design of X**
 5. **Make a poster / marketing asset** (flyer, cover art, social feed post, story, channel cover, thumbnail, ad creative) — a static artwork, not a page. Skip repo init/analysis; read [GRAPHIC.md](references/GRAPHIC.md) and follow it (you generate the key visual with your own image tool, upload it, then compose the artwork on a fixed canvas; platform dimension table included).
 6. **Design from a live website / reference URL** (borrow a style, restyle, recombine, or plan a rebuild) — extract a reference site's design DNA (style guide, design tokens, content structure, brand assets, a static reference clone) with `extract-website`, then design with it. Read [WEBSITE.md](references/WEBSITE.md) and follow its recipes. Note: via the CLI a "recreate"/"clone" is a **style-informed rebuild** — faithful pixel-recreation and *editable* on-canvas clones are done in the Superdesign app (superdesign.dev), not the CLI.
+7. **Design with your own model** — when the user explicitly asks, or `create-design-draft` / `iterate-design-draft` still fails after one retry, follow [design-with-your-model.md](references/design-with-your-model.md) to author and import the draft yourself.
 
 # Step 0 — Environment preflight (BEFORE any CLI step)
 
@@ -97,7 +98,7 @@ If init is complete (all six files present and non-empty), you MUST read ALL of 
 
 - **Auth/login error** (the CLI ran but rejected the session): run `login` (above), then retry the intended command ONCE. If login itself fails (headless/no-browser auth, expired flow, user declines), tell the user plainly and STOP — do not keep retrying or improvise.
 - **`extract-website` fails or times out** (it can take ~60–120s): retry ONCE. If it still fails, offer to continue WITHOUT the extraction (design from the conversation / existing design system) rather than blocking.
-- **General rule:** retry a failed command at most once, then report the failure to the user and stop — never silently loop or fall back to inventing output.
+- **General rule:** retry a failed command at most once. If `create-design-draft` or `iterate-design-draft` still fails, continue via [design-with-your-model.md](references/design-with-your-model.md); otherwise report the failure and stop.
 
 ## Command examples
 

--- a/skills/superdesign/references/design-with-your-model.md
+++ b/skills/superdesign/references/design-with-your-model.md
@@ -1,0 +1,26 @@
+# Design with your model
+
+Use this path only when the user explicitly asks the current Agent to design, or when `create-design-draft` / `iterate-design-draft` still fails after one retry. It replaces only the draft-generation step; keep the selected SOP, repo init, design-system context, assets, and canvas handoff unchanged.
+
+1. Run `npx --yes @superdesign/cli@latest import-design-draft --help` and follow its HTML contract.
+2. Author one complete draft document in `.superdesign/tmp/<name>.html` using the context already gathered for the normal design path.
+3. For a new draft, import it with an explicit viewport:
+
+   ```bash
+   npx --yes @superdesign/cli@latest import-design-draft \
+     --project-id <id> --title "<title>" --device desktop \
+     --html-file .superdesign/tmp/<name>.html \
+     --generated-by <your-real-model-id> --user-request "<verbatim-user-request>"
+   ```
+
+4. To revise an existing draft, fetch it with `get-design`, edit its HTML, then import a revertible version:
+
+   ```bash
+   npx --yes @superdesign/cli@latest import-design-draft --into <draft-id> \
+     --html-file .superdesign/tmp/<name>.html \
+     --generated-by <your-real-model-id> --user-request "<verbatim-user-request>"
+   ```
+
+5. Act on any returned `warnings[]`, then surface the returned `canvas` URL as usual.
+
+Use the real model identifier exposed by the harness. If none is available, omit `--generated-by` instead of inventing one. Use `--width`/`--height` for a custom viewport and add `--kind graphic` for fixed-canvas graphics; read `--help` rather than guessing other flags.


### PR DESCRIPTION
## What changed

- add a small `Design with your own model` entry to the skill
- route explicit requests and exhausted create/iterate retries to a focused reference
- document the minimal `import-design-draft` create and update workflow

## Why

This lets the caller model act as the designer when requested, or as a fallback after platform generation keeps failing, without expanding the main skill workflow.

## Validation

- `quick_validate.py skills/superdesign`
- `git diff --check`
- verified `import-design-draft --help` against `@superdesign/cli@latest`
