### PR TITLE
chore(plugin): bump to 0.4.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "superdesign",
   "displayName": "Superdesign",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Design or redesign frontend UI and marketing graphics on the Superdesign infinite canvas. Reads your codebase for context, sets up a design system, and generates branchable design drafts you refine.",
   "author": {
     "name": "Superdesign dev, Inc.",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "superdesign",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Superdesign adds a design skill to ChatGPT that spans both web UI and graphics.",
   "author": {
     "name": "Superdesign dev, Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ Both plugin manifests carry an explicit `version`, so marketplaces only hand use
 field is bumped — every release entry below corresponds to a `chore(plugin): bump to X.Y.Z` commit that
 bumps `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` together.
 
-## Unreleased
+## 0.4.2
 
+- Add a `Design with your own model` path that imports caller-authored HTML when explicitly requested
+  or after `create-design-draft` / `iterate-design-draft` exhausts its retry.
 - Package the repo as a Claude Code plugin: `.claude-plugin/plugin.json` manifest, plus a self-hosted
   `.claude-plugin/marketplace.json` so it installs with
   `/plugin marketplace add superdesigndev/superdesign-skill` +


### PR DESCRIPTION
## What changed

- bump the Codex and Claude plugin manifests from `0.4.1` to `0.4.2`
- finalize the `0.4.2` changelog entry, including the new `Design with your own model` path

## Why

Both marketplaces use the explicit manifest version as their update cache key, so the merged skill change needs a coordinated version bump to ship to users.

## Validation

- `git diff --check`
- `claude plugin validate ./.claude-plugin/plugin.json --strict`
- `claude plugin validate ./.claude-plugin/marketplace.json --strict`
