### PR TITLE
chore(plugin): bump to 0.4.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "superdesign",
   "displayName": "Superdesign",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Design or redesign frontend UI and marketing graphics on the Superdesign infinite canvas. Reads your codebase for context, sets up a design system, and generates branchable design drafts you refine.",
   "author": {
     "name": "Superdesign dev, Inc.",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "superdesign",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Superdesign adds a design skill to ChatGPT that spans both web UI and graphics.",
   "author": {
     "name": "Superdesign dev, Inc.",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The Superdesign design skill for Cursor, published by Superdesign dev, Inc.",
-    "version": "0.4.2"
+    "version": "0.4.3"
   },
   "plugins": [
     {

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "superdesign",
   "displayName": "Superdesign",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Design or redesign frontend UI and marketing graphics on the Superdesign infinite canvas. Reads your codebase for context, sets up a design system, and generates branchable design drafts you refine.",
   "author": {
     "name": "Superdesign dev, Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,10 @@ All plugin manifests carry an explicit `version`, so marketplaces only hand user
 field is bumped — every release entry below corresponds to a `chore(plugin): bump to X.Y.Z` commit that
 bumps `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, and `.cursor-plugin/plugin.json` together.
 
-## Unreleased
+## 0.4.3
 
 - Add Cursor plugin packaging (`.cursor-plugin/plugin.json` + `.cursor-plugin/marketplace.json`) for the
   Cursor marketplace, off the same `skills/superdesign/` tree.
-
-## Unreleased
-
 - Reuse safe `.superdesign/resume.json` state across sessions so an initialized UI target keeps its
   project, drafts, components, and budgeted source context without repeating discovery or reproduction.
   Changed source is repaired incrementally with precise Git diffs when available; flow pages remain


### PR DESCRIPTION
## Summary
- bump Codex, Claude Code, and Cursor plugin manifests to 0.4.3
- keep Cursor marketplace metadata on the same version
- consolidate the merged Cursor packaging and cross-session context reuse notes under the 0.4.3 changelog entry

## Validation
- git diff --check
- strict Claude plugin manifest validation
- strict Claude marketplace manifest validation
- JSON parsing for Codex, Claude, and Cursor manifests/marketplace files