### PR TITLE
chore(plugin): bump to 0.4.4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "superdesign",
   "displayName": "Superdesign",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Design or redesign frontend UI and marketing graphics on the Superdesign infinite canvas. Reads your codebase for context, sets up a design system, and generates branchable design drafts you refine.",
   "author": {
     "name": "Superdesign dev, Inc.",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "superdesign",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Superdesign adds a design skill to ChatGPT that spans both web UI and graphics.",
   "author": {
     "name": "Superdesign dev, Inc.",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The Superdesign design skill for Cursor, published by Superdesign dev, Inc.",
-    "version": "0.4.3"
+    "version": "0.4.4"
   },
   "plugins": [
     {

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "superdesign",
   "displayName": "Superdesign",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Design or redesign frontend UI and marketing graphics on the Superdesign infinite canvas. Reads your codebase for context, sets up a design system, and generates branchable design drafts you refine.",
   "author": {
     "name": "Superdesign dev, Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ root `package.json` (the DeepSeek Harness bundle) together.
 
 ## Unreleased
 
+## 0.4.4
+
+- Make local project assets visibly reliable: discover and upload relevant logos, fonts, screenshots,
+  and images; place uploaded images predictably on the canvas; and use an available project logo
+  wherever a design or reusable component calls for one.
+- Route iteration by user intent: refine an accepted direction in place, reserve branches for genuine
+  alternatives, use Superdesign replacement generation for creative recomposition, and use direct,
+  reversible draft versions for exact local-model corrections.
+- Carry selected visual references into generation and reuse existing assets before generating new
+  imagery, while keeping caller-authored HTML imports conformant and recoverable.
+
 - Add DeepSeek Harness (`dsh`) packaging off the same `skills/superdesign/` tree: a root `package.json`
   declaring `dsh.bundle`, plus `dsh/cordis.patch.yml` and a dependency-free `dsh/index.js` that publishes
   the skill on `ctx.skills`. Installs with

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superdesign-dsh",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "type": "module",
   "description": "Design or redesign frontend UI and marketing graphics on the Superdesign infinite canvas — the Superdesign skill, packaged as a DeepSeek Harness bundle.",
   "main": "dsh/index.js",


### PR DESCRIPTION
## Summary
- bump the Codex, Claude Code, Cursor, and DeepSeek Harness plugin manifests from `0.4.3` to `0.4.4`
- keep the Cursor marketplace cache version synchronized
- publish release notes for reliable local assets, intent-aware refinement routing, selected visual references, and DeepSeek Harness packaging

## Validation
- parsed every JSON manifest
- `claude plugin validate ./.claude-plugin/plugin.json --strict`
- `claude plugin validate ./.claude-plugin/marketplace.json --strict`
- `git diff --check`

This repository releases marketplace updates through the merged manifest version; no release tag or publish workflow is required.