### PR TITLE
Add image and video asset generation guidance

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "superdesign",
   "displayName": "Superdesign",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "description": "Design or redesign frontend UI and marketing graphics on the Superdesign infinite canvas. Reads your codebase for context, sets up a design system, and generates branchable design drafts you refine.",
   "author": {
     "name": "Superdesign dev, Inc.",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "superdesign",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "description": "Superdesign adds a design skill to ChatGPT that spans both web UI and graphics.",
   "author": {
     "name": "Superdesign dev, Inc.",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "superdesign",
   "displayName": "Superdesign",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "description": "Design or redesign frontend UI and marketing graphics on the Superdesign infinite canvas. Reads your codebase for context, sets up a design system, and generates branchable design drafts you refine.",
   "author": {
     "name": "Superdesign dev, Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,16 @@ field is bumped — every release entry below corresponds to a `chore(plugin): b
 bumps `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, `.cursor-plugin/plugin.json`, and the
 root `package.json` (the DeepSeek Harness bundle) together.
 
-## Unreleased
+## 0.5.0
+
+- Add image and video asset generation guidance for the Superdesign CLI: prefer a host agent's native
+  image generator for ordinary assets, use Superdesign when its model catalog or generation ledger is
+  specifically useful, and route generated video through Superdesign.
+- Add `ASSET_GENERATION.md` to decide when original pixels or motion improve a design, distinguish
+  final content from temporary visual references and durable Brand Assets, and carry generated results
+  into design drafts through their public URL and canvas node id.
+- Keep the paid generation mechanics discoverable through live CLI help and returned hints, while
+  preserving the explicit quote confirmation boundary and idempotent timeout recovery rule.
 
 ## 0.4.4
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superdesign-dsh",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "type": "module",
   "description": "Design or redesign frontend UI and marketing graphics on the Superdesign infinite canvas — the Superdesign skill, packaged as a DeepSeek Harness bundle.",
   "main": "dsh/index.js",

--- a/skills/superdesign/references/ASSET_GENERATION.md
+++ b/skills/superdesign/references/ASSET_GENERATION.md
@@ -1,0 +1,100 @@
+# Image & Video Asset Generation
+
+Read this when a design needs a new image or video asset. Decide what visual role the asset serves before choosing a generator. CLI flags and model capabilities change; discover the current surface with `list-models` and `<command> --help` rather than carrying a static parameter manual here.
+
+## Decide whether to generate
+
+Use an existing asset when the user or product already has the right logo, product image, illustration, screenshot, brand artwork, or footage. Do not regenerate identity assets or replace deliberate product content with synthetic substitutes.
+
+Generate an image when the design needs original pixels that cannot be produced well by HTML/CSS alone, such as:
+
+- a hero or campaign key visual
+- a product/lifestyle scene or editorial still life
+- an illustration, atmospheric background, texture, or empty-state artwork
+- a poster, cover, social creative, or ad visual that will be composed with text separately
+
+Do not generate ordinary UI controls, icons, logos, readable interface screenshots, or text-heavy artwork. Build UI and typography in the design draft; generated images should normally contain no text. For posters and marketing graphics, follow [GRAPHIC.md](GRAPHIC.md): generate only the key visual, leave deliberate negative space for copy, and compose all text in the HTML layer.
+
+Generate video when motion itself is the asset, such as:
+
+- a short hero/background loop
+- a product or environment reveal
+- image-to-video animation of a selected still or first frame
+- a social clip, campaign motion asset, or cinematic transition
+
+Do not generate video when a static image, CSS animation, or normal UI motion communicates the same thing more clearly and cheaply.
+
+## Choose the generation path
+
+### Image: prefer the host's native generator
+
+If the host agent already has image generation (for example, the Codex harness), use it for ordinary image assets. It is the shortest path, avoids Superdesign generation credits, and gives the agent direct control over iteration. Import the selected result as project content:
+
+```bash
+npx --yes @superdesign/cli@latest upload-asset <file> \
+  --project-id <project-id> --purpose content \
+  --key "<stable-key>" --description "<visual role>"
+```
+
+Use `--purpose reference` instead when the generated image is only inspiration and must not appear in the final design. Reuse the returned public URL and canvas node id; do not re-upload unchanged bytes.
+
+### Image: use Superdesign for a deliberate reason
+
+Use `generate-image` when one or more of these apply:
+
+- the user requests a specific Superdesign model
+- the user wants to compare outputs from different models
+- the desired model is better suited to the task than the host-native generator
+- the generation should be tracked in the Superdesign asset ledger
+- the host has no native image-generation capability
+
+Inspect the live catalog before choosing. Tell the user which model you picked and the task-specific reason, such as stronger reference following, better textural detail, faster ideation, or higher output resolution:
+
+```bash
+npx --yes @superdesign/cli@latest list-models --type image
+npx --yes @superdesign/cli@latest list-models <model-id>
+npx --yes @superdesign/cli@latest generate-image --help
+```
+
+Then quote with `generate-image`. Shape the prompt around the asset's role in the design: subject and composition first, intended crop/aspect, location of negative space, lighting/material/style, and any supplied visual reference. Avoid asking the image model to solve page layout or render final UI copy.
+
+### Video: use Superdesign
+
+Superdesign is the generation path for video in this skill:
+
+```bash
+npx --yes @superdesign/cli@latest list-models --type video
+npx --yes @superdesign/cli@latest list-models <model-id>
+npx --yes @superdesign/cli@latest generate-video --help
+```
+
+Choose text-to-video when the scene can be described from scratch. Choose image-to-video when composition, subject identity, product appearance, or the opening frame must be controlled; use the selected canvas node, Brand Asset key, or public image URL as the source image. The source image determines the frame ratio, so an explicit aspect ratio belongs only to text-to-video.
+
+In the prompt, describe the action over time: subject motion, camera behavior, environmental movement, pacing, and what must remain stable. Prefer short, focused clips over several unrelated actions in one generation. Inspect the selected model's schema for its actual duration, resolution, source-image, camera, seed, and prompt-optimizer support.
+
+## Quote and confirm
+
+`generate-image` and `generate-video` create a free quote and print the exact confirmation command. Relay the model, important output settings, quoted credits, and balance to the user. Run `confirm-generation` only after the user explicitly confirms that quoted price in this conversation; its `--credits` value must match the quote exactly.
+
+Use the CLI response as the procedural guide instead of restating every flag here:
+
+```bash
+npx --yes @superdesign/cli@latest confirm-generation --help
+npx --yes @superdesign/cli@latest get-generation --help
+npx --yes @superdesign/cli@latest list-generations --help
+```
+
+One recovery rule is load-bearing: image/video confirmation is idempotent. If a host timeout interrupts `confirm-generation`, re-run the exact same command or continue with `get-generation <id> --wait`. Never request a replacement quote after confirmation has started; the original generation may still be running and retrying the same id will not double-charge.
+
+## Put the result into the design
+
+Keep the successful result's public asset URL and canvas node id. Use the URL in the design prompt or final HTML when the asset must visibly render, and pass the node id so the design model sees the actual pixels:
+
+```bash
+npx --yes @superdesign/cli@latest create-design-draft \
+  --project-id <project-id> --title "<title>" \
+  --reference-id <generated-node-id> \
+  -p "Use the supplied image as <specific visual role>."
+```
+
+The same reference id can guide an iteration or flow generation where those commands accept `--reference-id`. A generated image intended for the final design is project content, not a Brand Asset merely because it appears prominently. Preserve logos, fonts, and reusable identity under the normal Brand Asset workflow.

--- a/skills/superdesign/references/SUPERDESIGN.md
+++ b/skills/superdesign/references/SUPERDESIGN.md
@@ -423,6 +423,12 @@ Every command takes `--json` for the full machine payload, and `--full` expands 
 - `get-prompts`: index with the default output first, then re-run with `--full` for the chosen slug(s) only.
 - `create-project` auto-opens the browser — see Browser Choice in [SKILL.md](../SKILL.md). Revert and `--from-version` semantics live in VERSION HISTORY & REVERT.
 
+### Image & Video Generation (quote → confirm; spends credits)
+
+Read [ASSET_GENERATION.md](ASSET_GENERATION.md) whenever the work needs a new image or video asset. Prefer existing/user-provided assets first. For a new image, prefer the host agent's native image generation when available, then import it with `upload-asset`; use `generate-image` when the user requests a Superdesign model, wants model comparisons or ledger tracking, or the Superdesign catalog better fits the job. Use `generate-video` for generated video.
+
+Superdesign image/video generation is quote → confirm: quoting is free, while `confirm-generation` spends the displayed credits. Relay the quote and run its exact confirmation command only after the user explicitly approves that price in this conversation. Read the command's `--help` and follow its returned hints for current models, parameters, and recovery.
+
 ---
 
 ## EXTRACT-WEBSITE


### PR DESCRIPTION
Summary: add image/video asset generation routing; prefer host-native image generation for ordinary assets and Superdesign for selected image models, ledger tracking, and video; add ASSET_GENERATION.md; bump Codex, Claude, Cursor, and DSH manifests to 0.5.0. Validation: Superdesign CLI 0.12.0-beta.1 command help and model catalog checked; skill validation passed; Claude plugin and marketplace strict validation passed.