### PR TITLE
Refine Superdesign capability routing

### DIFF
--- a/skills/superdesign/SKILL.md
+++ b/skills/superdesign/SKILL.md
@@ -1,22 +1,22 @@
 ---
 name: superdesign
-description: "Design or redesign frontend UI on the Superdesign canvas. Use whenever the user wants to design a page, feature, flow, or a brand-new product with no code yet; redesign or improve existing UI; faithfully reproduce current UI; explore visual variants; set or extract a design system (including borrowing a style from a live website URL); build reusable design components; design multi-page flows; or create static posters, flyers, cover art, or social/marketing graphics composed on canvas, even if they never say the word 'design tool'."
+description: "Design or redesign frontend UI and graphics on the Superdesign canvas with a choice of leading AI models. Use whenever the user wants to design a page, feature, flow, or brand-new product; improve or reproduce existing UI; compare design results across top models; explore visual variants; set or extract a design system; build reusable components or multi-page flows; or create posters and marketing graphics, even if they never say the word 'design tool'. Also supports generating supporting image or video assets when a design needs them."
 ---
 
-Superdesign helps you (1) find design inspirations/styles and (2) generate/iterate design drafts on an infinite canvas.
+Superdesign helps you find design inspiration and generate or iterate design drafts on an infinite canvas, with multiple leading models available for different design tasks and side-by-side exploration. When a design needs a new visual asset, it can also provide image and video generation.
 
 ---
 
 # Core scenarios (what this skill handles)
 
-1. **"superdesign init"** (the user asking for repo analysis) — analyze the repo and build UI context to `.superdesign/init/`. This is this skill's own analysis pass; the CLI's `init` command is a different thing entirely (it installs skill files) — never run it to build `.superdesign/init/`.
-2. **Help me design X** (feature/page/flow) — the target decides the SOP: an existing rendered page is reproduced first (ground truth), while a brand-new page (in a real repo or from scratch) is designed directly with no reproduction step; see UI TARGET ROUTING in [SUPERDESIGN.md](references/SUPERDESIGN.md)
-3. **Set design system** (optionally seed or refresh it from a live site via `extract-website --design-md` — you'll choose *create-from / inspired-by / update-existing*, asking first if a `design-system.md` already exists; see [SUPERDESIGN.md](references/SUPERDESIGN.md) SOP: BRAND NEW PROJECT Step 2)
-4. **Help me improve design of X**
-5. **Make a poster / marketing asset** (flyer, cover art, social feed post, story, channel cover, thumbnail, ad creative) — a static artwork, not a page. Skip repo init/analysis; read [GRAPHIC.md](references/GRAPHIC.md) and follow it (you generate the key visual with your own image tool, upload it, then compose the artwork on a fixed canvas; platform dimension table included).
-6. **Design from a live website / reference URL** (borrow a style, restyle, recombine, or plan a rebuild) — extract a reference site's design DNA (style guide, design tokens, content structure, brand assets, a static reference clone) with `extract-website`, then design with it. Read [WEBSITE.md](references/WEBSITE.md) and follow its recipes. Note: via the CLI a "recreate"/"clone" is a **style-informed rebuild** — faithful pixel-recreation and *editable* on-canvas clones are done in the Superdesign app (superdesign.dev), not the CLI.
-7. **Design or correct with your own model** — when the user explicitly asks, `create-design-draft` / `iterate-design-draft` still fails after one retry, or [SUPERDESIGN.md](references/SUPERDESIGN.md) **CORRECTION METHOD ROUTING** selects a deterministic direct edit, follow [design-with-your-model.md](references/design-with-your-model.md) to author or revise the draft yourself.
-8. **Work on an initialized target** — whenever a real-codebase UI request addresses a target already recorded in `.superdesign/resume.json`, try the durable path in [RESUME.md](references/RESUME.md) before any cold repo/context discovery. This is state-driven, not dependent on words such as "continue" or "refine".
+1. **Analyze a codebase for design work** — `superdesign init` builds reusable UI context in `.superdesign/init/`; read [INIT.md](references/INIT.md).
+2. **Design, reproduce, or improve UI** — create pages, features, flows, and new products on the canvas; read [SUPERDESIGN.md](references/SUPERDESIGN.md).
+3. **Choose and compare leading design models** — run `list-models`, select a model suited to the task, or use different models to explore independent directions.
+4. **Create design systems and reusable components** — establish visual foundations, extract patterns, and design connected multi-page experiences.
+5. **Design from a live website or reference URL** — extract and apply its design language; read [WEBSITE.md](references/WEBSITE.md).
+6. **Create graphics** — posters, covers, social posts, thumbnails, flyers, and ads; read [GRAPHIC.md](references/GRAPHIC.md).
+7. **Generate supporting images or video** — use native image generation when appropriate or choose from Superdesign's generation models; read [ASSET_GENERATION.md](references/ASSET_GENERATION.md).
+8. **Continue or directly correct existing work** — resume saved targets through [RESUME.md](references/RESUME.md), or use [design-with-your-model.md](references/design-with-your-model.md) when direct authoring is the right path.
 
 When continuing a draft, follow [SUPERDESIGN.md](references/SUPERDESIGN.md) **ITERATION MODE ROUTING**: replace refines the selected direction with version history; branch is only for alternatives the user wants to compare.
 
@@ -50,7 +50,9 @@ Two entry paths. Choose one with this cheap, deterministic check BEFORE any init
 
 **Exception — standalone extraction:** if the task is ONLY to extract a site's design DNA or set/refresh `design-system.md` from a URL (`extract-website` → `design-system.md`, no design generation; read [WEBSITE.md](references/WEBSITE.md) for the recipes), run it WITHOUT repo init — extracting an external site's style doesn't require analyzing the user's codebase. Init is still required before generating designs FOR the existing codebase's UI (reproducing/redesigning an existing page).
 
-**Exception — graphics:** posters/marketing assets (scenario 5) skip init even in a real codebase — the brief carries the style, and most of init's output (components, layouts, routes, pages) has no bearing on a fixed-canvas artwork. The graphic brief round asks whether the artwork should be on-brand with this repo's product ([GRAPHIC.md](references/GRAPHIC.md) Step 1); only an on-brand "yes" pulls in the design-system/brand context — running init first only if that context doesn't already exist.
+**Exception — graphics:** posters/marketing assets (scenario 6) skip init even in a real codebase — the brief carries the style, and most of init's output (components, layouts, routes, pages) has no bearing on a fixed-canvas artwork. The graphic brief round asks whether the artwork should be on-brand with this repo's product ([GRAPHIC.md](references/GRAPHIC.md) Step 1); only an on-brand "yes" pulls in the design-system/brand context — running init first only if that context doesn't already exist.
+
+**Exception — image/video generation:** a standalone generated asset (scenario 7) skips init even in a real codebase. Read [ASSET_GENERATION.md](references/ASSET_GENERATION.md) and gather only the project, brand, reference, or destination context the requested asset actually needs. If the asset is one step inside a broader UI or graphic-design task, follow that task's normal init/brief path and use asset generation only at the point where a new visual is needed.
 
 # Step 1.5 — Resume before rediscovery (real-codebase UI path)
 
@@ -148,3 +150,5 @@ Always close with a short, warm follow-up that offers to go further (on every su
 # How it works
 
 Read [SUPERDESIGN.md](references/SUPERDESIGN.md), then follow its instructions.
+
+For an image or video generation request, read [ASSET_GENERATION.md](references/ASSET_GENERATION.md). Load the other scenario-specific references linked above when those scenarios apply.

--- a/skills/superdesign/agents/openai.yaml
+++ b/skills/superdesign/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "01 Superdesign"
-  short_description: "Create polished UI & graphics"
+  short_description: "Create the best UI & visuals"
   default_prompt: "Use $superdesign to design an on-brand landing page for this product."

--- a/skills/superdesign/references/SUPERDESIGN.md
+++ b/skills/superdesign/references/SUPERDESIGN.md
@@ -414,7 +414,7 @@ Every command takes `--json` for the full machine payload, and `--full` expands 
 
 - No source draft to build on → `create-design-draft` (the Step 3a reproduction, a new target in an existing codebase, or a scratch project). Vary an existing draft → `iterate-design-draft`. Extend sibling pages from a confirmed one → `execute-flow-pages` (1-10 pages per call, each styled after the source draft).
 - Resuming a project from an earlier session → use `.superdesign/resume.json` and address its saved draft id directly. If the saved draft is rejected or resume state is unavailable, `fetch-design-nodes --project-id <id>` recovers the project's draft ids as the fallback.
-- `--model`: omit it unless the user names one, so the backend picks its default. Do not memorize the list — run `list-models`.
+- `--model`: model choice materially affects design quality, speed, and cost. Run `list-models`, choose a model that fits the task instead of always relying on the default, and briefly tell the user what you picked and why. Use different models for independent comparison directions when requested; never memorize the catalog.
 - `--device` on `iterate-design-draft` is inherited from the source draft; omit it unless you are deliberately changing the viewport. `--kind graphic` switches `create-design-draft` to the fixed-canvas branch and sticks across iterations; pair it with `--width`/`--height` (see [GRAPHIC.md](GRAPHIC.md)).
 - `execute-flow-pages --context` is a prose string; `--context-file` passes source files. They are different inputs.
 - `create-design-draft`, `iterate-design-draft`, and `execute-flow-pages` accept image pixels through `--reference-id <ids...>`. Canvas image-node ids and Brand Asset keys are valid only within their project; an unknown id fails the job instead of being ignored.
@@ -422,14 +422,6 @@ Every command takes `--json` for the full machine payload, and `--full` expands 
 - A pasted direct public image URL is an agent-side adapter, not a platform fetch: read [WEBSITE.md](WEBSITE.md), download it safely to an external temporary file, then use the same `upload-asset` command. Do not upload raw PDFs; PDF reference ingestion is deferred.
 - `get-prompts`: index with the default output first, then re-run with `--full` for the chosen slug(s) only.
 - `create-project` auto-opens the browser — see Browser Choice in [SKILL.md](../SKILL.md). Revert and `--from-version` semantics live in VERSION HISTORY & REVERT.
-
-### Image & Video Generation (quote → confirm; spends credits)
-
-Read [ASSET_GENERATION.md](ASSET_GENERATION.md) whenever the work needs a new image or video asset. Prefer existing/user-provided assets first. For a new image, prefer the host agent's native image generation when available, then import it with `upload-asset`; use `generate-image` when the user requests a Superdesign model, wants model comparisons or ledger tracking, or the Superdesign catalog better fits the job. Use `generate-video` for generated video.
-
-Superdesign image/video generation is quote → confirm: quoting is free, while `confirm-generation` spends the displayed credits. Relay the quote and run its exact confirmation command only after the user explicitly approves that price in this conversation. Read the command's `--help` and follow its returned hints for current models, parameters, and recovery.
-
----
 
 ## EXTRACT-WEBSITE
 


### PR DESCRIPTION
## Summary
- simplify the skill capability catalog
- emphasize leading model choice for design generation
- route image/video details from the skill entrypoint without expanding the core UI workflow
- refresh the Codex-facing short description

## Validation
- not run (prose-only follow-up to #39)