### PR TITLE
Bump plugins to 0.5.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "superdesign",
   "displayName": "Superdesign",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Design or redesign frontend UI and marketing graphics on the Superdesign infinite canvas. Reads your codebase for context, sets up a design system, and generates branchable design drafts you refine.",
   "author": {
     "name": "Superdesign dev, Inc.",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "superdesign",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Superdesign adds a design skill to ChatGPT that spans both web UI and graphics.",
   "author": {
     "name": "Superdesign dev, Inc.",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "superdesign",
   "displayName": "Superdesign",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Design or redesign frontend UI and marketing graphics on the Superdesign infinite canvas. Reads your codebase for context, sets up a design system, and generates branchable design drafts you refine.",
   "author": {
     "name": "Superdesign dev, Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ field is bumped — every release entry below corresponds to a `chore(plugin): b
 bumps `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, `.cursor-plugin/plugin.json`, and the
 root `package.json` (the DeepSeek Harness bundle) together.
 
+## 0.5.1
+
+- Simplify the skill entrypoint into a concise capability catalog while keeping detailed workflows in
+  their scenario-specific references.
+- Highlight task-aware selection and comparison across leading design-generation models.
+- Route supporting image and video generation from the skill entrypoint and align the Codex-facing
+  description around creating the best UI and visuals.
+
 ## 0.5.0
 
 - Add image and video asset generation guidance for the Superdesign CLI: prefer a host agent's native

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superdesign-dsh",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "description": "Design or redesign frontend UI and marketing graphics on the Superdesign infinite canvas — the Superdesign skill, packaged as a DeepSeek Harness bundle.",
   "main": "dsh/index.js",


### PR DESCRIPTION
## Summary
- bump Codex, Claude Code, Cursor, and DeepSeek Harness manifests to 0.5.1
- add the 0.5.1 changelog entry for the refined capability routing and model-choice guidance

## Validation
- not run (version and changelog-only release commit)