### PR TITLE
chore(plugin): bump to 0.6.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "superdesign",
   "displayName": "Superdesign",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Design or redesign frontend UI, presentations, and marketing graphics on the Superdesign infinite canvas. Uses approved slide outlines, project context, and branchable drafts you refine.",
   "author": {
     "name": "Superdesign dev, Inc.",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "superdesign",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Superdesign adds a design skill to ChatGPT for web UI, presentations, and graphics.",
   "author": {
     "name": "Superdesign dev, Inc.",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "superdesign",
   "displayName": "Superdesign",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Design or redesign frontend UI, presentations, and marketing graphics on the Superdesign infinite canvas. Uses approved slide outlines, project context, and branchable drafts you refine.",
   "author": {
     "name": "Superdesign dev, Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ field is bumped — every release entry below corresponds to a `chore(plugin): b
 bumps `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, `.cursor-plugin/plugin.json`, and the
 root `package.json` (the DeepSeek Harness bundle) together.
 
-## Unreleased
+## 0.6.0
 
 - Add a presentation workflow with host-agent requirements reasoning, visual-direction selection, and
   editable outline approval before generation.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superdesign-dsh",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "type": "module",
   "description": "Design frontend UI, presentations, and marketing graphics on the Superdesign infinite canvas — packaged as a DeepSeek Harness skill bundle.",
   "main": "dsh/index.js",


### PR DESCRIPTION
## Summary

- bump Codex, Claude Code, Cursor, and DeepSeek Harness plugin manifests to 0.6.0
- release the presentation workflow changelog entry

## Validation

- Codex plugin validation passed
- Claude plugin manifest strict validation passed
- Claude marketplace strict validation passed
- all four release manifests report 0.6.0